### PR TITLE
Feat: 트렌딩 및 특정 레포지토리 조회 기능 구현

### DIFF
--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -1,0 +1,32 @@
+#services:
+#  app:
+#    build: .
+#    image: harryest/openstep:dev
+#    ports:
+#      - "8080:8080"
+#    environment:
+#      SPRING_DATASOURCE_URL: jdbc:mysql://openstep.cpgoe06g6rjt.ap-northeast-2.rds.amazonaws.com:3306/openstep_db
+#      SPRING_DATASOURCE_USERNAME: root
+#      SPRING_DATASOURCE_PASSWORD: Capstoneteam01!
+#    depends_on:
+#      - mysql-db
+#    networks:
+#      - openstep-network
+#
+#  mysql-db:
+#    image: mysql:8.0
+#    environment:
+#      MYSQL_ROOT_PASSWORD: root
+#      MYSQL_DATABASE: openstep_db
+#    ports:
+#      - "3306:3306"
+#    volumes:
+#      - mysql-data:/var/lib/mysql
+#    networks:
+#      - openstep-network
+#
+#networks:
+#  openstep-network:
+#
+#volumes:
+#  mysql-data:

--- a/src/main/java/com/chungang/capstone/openstep/OpenstepApplication.java
+++ b/src/main/java/com/chungang/capstone/openstep/OpenstepApplication.java
@@ -2,7 +2,9 @@ package com.chungang.capstone.openstep;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class OpenstepApplication {
 

--- a/src/main/java/com/chungang/capstone/openstep/domain/Rank/entity/Rank.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Rank/entity/Rank.java
@@ -16,6 +16,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(name = "member_rank")
 public class Rank extends BaseEntity {
 
     @Id

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/controller/RepoController.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/controller/RepoController.java
@@ -1,4 +1,49 @@
 package com.chungang.capstone.openstep.domain.Repo.controller;
 
+import com.chungang.capstone.openstep.domain.Repo.service.RepoQueryService;
+import com.chungang.capstone.openstep.global.apiPayload.code.status.SuccessStatus;
+import com.chungang.capstone.openstep.global.apiPayload.ApiResponse;
+import com.chungang.capstone.openstep.domain.Repo.converter.RepoConverter;
+import com.chungang.capstone.openstep.domain.Repo.dto.RepoResponseDTO;
+import com.chungang.capstone.openstep.domain.Repo.entity.Repo;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.parameters.P;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/repo")
+@Tag(name = "레포지토리 API", description = "레포지토리 관련 API입니다.")
 public class RepoController {
+
+    private final RepoQueryService repoQueryService;
+
+    // 트렌딩 레포지토리 목록 조회 API
+    @GetMapping("/trending")
+    @Operation(summary = "트렌딩 레포지토리 조회 API", description = "현재 인기 있는 트렌딩한 오픈소스 레포지토리를 조회합니다.")
+    public ApiResponse<List<RepoResponseDTO.TrendingRepoDTO>> getTrendingRepos() {
+        List<Repo> repos = repoQueryService.getTrendingRepos();
+        return ApiResponse.onSuccess(SuccessStatus.REPO_GET_TRENDING_OK, RepoConverter.toTrendingDTOs(repos));
+    }
+
+    // 특정 레포지토리 상세 조회
+    @GetMapping("/{repo-id}")
+    @Operation(summary = "특정 레포지토리 상세 조회 API", description = "특정 오픈소스 레포지토리의 상세 정보를 조회합니다.")
+    public ApiResponse<RepoResponseDTO.RepoDetailDTO> getRepoDetail(@PathVariable("repo-id") Long repoId) {
+        Repo repo = repoQueryService.getRepoById(repoId);
+        return ApiResponse.onSuccess(SuccessStatus.REPO_GET_DETAIL_OK, RepoConverter.toRepoDetailDTO(repo));
+    }
 }
+

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/converter/RepoConverter.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/converter/RepoConverter.java
@@ -1,4 +1,39 @@
 package com.chungang.capstone.openstep.domain.Repo.converter;
 
+import com.chungang.capstone.openstep.domain.Repo.dto.RepoResponseDTO;
+import com.chungang.capstone.openstep.domain.Repo.entity.Repo;
+
+import java.util.List;
+
 public class RepoConverter {
+
+    public static List<RepoResponseDTO.TrendingRepoDTO> toTrendingDTOs(List<Repo> repos) {
+        return repos.stream()
+                .map(repo -> RepoResponseDTO.TrendingRepoDTO.builder()
+                        .repoId(repo.getRepoId())
+                        .repoName(repo.getRepoName())
+                        .ownerName(repo.getOwnerName())
+                        .language(repo.getLanguage())
+                        .stars(repo.getStars())
+                        .githubUrl(repo.getGithubUrl())
+                        .build())
+                .toList();
+    }
+
+    public static RepoResponseDTO.RepoDetailDTO toRepoDetailDTO(Repo repo) {
+        return RepoResponseDTO.RepoDetailDTO.builder()
+                .repoId(repo.getRepoId())
+                .repoName(repo.getRepoName())
+                .ownerName(repo.getOwnerName())
+                .description(repo.getDescription())
+                .language(repo.getLanguage())
+                .stars(repo.getStars())
+                .watchers(repo.getWatchers())
+                .forks(repo.getForks())
+                .openIssues(repo.getOpenIssues())
+                .closedIssues(repo.getClosedIssues())
+                .githubUrl(repo.getGithubUrl())
+                .readmeUrl(repo.getReadmeUrl())
+                .build();
+    }
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/converter/RepoConverter.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/converter/RepoConverter.java
@@ -15,10 +15,16 @@ public class RepoConverter {
                         .ownerName(repo.getOwnerName())
                         .language(repo.getLanguage())
                         .stars(repo.getStars())
+                        .watchers(repo.getWatchers())
+                        .forks(repo.getForks())
+                        .openIssues(repo.getOpenIssues())
+                        .closedIssues(repo.getClosedIssues())
                         .githubUrl(repo.getGithubUrl())
+                        .description(repo.getDescription())
                         .build())
                 .toList();
     }
+
 
     public static RepoResponseDTO.RepoDetailDTO toRepoDetailDTO(Repo repo) {
         return RepoResponseDTO.RepoDetailDTO.builder()

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/dto/GitHubGraphQLRequest.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/dto/GitHubGraphQLRequest.java
@@ -1,0 +1,12 @@
+package com.chungang.capstone.openstep.domain.Repo.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GitHubGraphQLRequest {
+    private String query;
+}

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/dto/GitHubRepoResponse.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/dto/GitHubRepoResponse.java
@@ -1,6 +1,8 @@
 package com.chungang.capstone.openstep.domain.Repo.dto;
 
 import lombok.Getter;
+import lombok.Setter;
+
 import java.util.List;
 
 @Getter
@@ -30,6 +32,42 @@ public class GitHubRepoResponse {
         private int stargazerCount;
         private Language primaryLanguage;
         private Owner owner;
+        private Integer forkCount;
+        private Issues openIssues;
+        private Issues closedIssues;
+        private Issues goodFirstIssue;
+        public Watchers watchers;
+        private String updatedAt;
+
+        public Integer getForkCount() {
+            return forkCount;
+        }
+
+        public int getWatchersCount() {
+            return watchers != null ? watchers.totalCount : 0;
+        }
+        public int getOpenIssuesCount() {
+            return openIssues != null ? openIssues.getTotalCount() : 0;
+        }
+
+        public int getClosedIssuesCount() {
+            return closedIssues != null ? closedIssues.getTotalCount() : 0;
+        }
+
+        public int getGoodFirstIssueCount() {
+            return goodFirstIssue != null ? goodFirstIssue.getTotalCount() : 0;
+        }
+    }
+
+    @Getter
+    public static class Watchers {
+        private int totalCount;
+    }
+
+    @Getter
+    @Setter
+    public static class Issues {
+        private int totalCount;
     }
 
     @Getter

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/dto/GitHubRepoResponse.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/dto/GitHubRepoResponse.java
@@ -1,0 +1,44 @@
+package com.chungang.capstone.openstep.domain.Repo.dto;
+
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+public class GitHubRepoResponse {
+    private Data data;
+
+    @Getter
+    public static class Data {
+        private Search search;
+    }
+
+    @Getter
+    public static class Search {
+        private List<Edge> edges;
+    }
+
+    @Getter
+    public static class Edge {
+        private Node node;
+    }
+
+    @Getter
+    public static class Node {
+        private String name;
+        private String description;
+        private String url;
+        private int stargazerCount;
+        private Language primaryLanguage;
+        private Owner owner;
+    }
+
+    @Getter
+    public static class Language {
+        private String name;
+    }
+
+    @Getter
+    public static class Owner {
+        private String login;
+    }
+}

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/dto/RepoResponseDTO.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/dto/RepoResponseDTO.java
@@ -16,8 +16,13 @@ public class RepoResponseDTO {
         private String repoName;
         private String ownerName;
         private String language;
-        private int stars;
+        private Integer stars;
+        private Integer watchers;
+        private Integer forks;
+        private Integer openIssues;
+        private Integer closedIssues;
         private String githubUrl;
+        private String description;
     }
 
     @Getter

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/dto/RepoResponseDTO.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/dto/RepoResponseDTO.java
@@ -1,0 +1,41 @@
+package com.chungang.capstone.openstep.domain.Repo.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class RepoResponseDTO {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class TrendingRepoDTO {
+        private Long repoId;
+        private String repoName;
+        private String ownerName;
+        private String language;
+        private int stars;
+        private String githubUrl;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class RepoDetailDTO {
+        private Long repoId;
+        private String repoName;
+        private String ownerName;
+        private String description;
+        private String language;
+        private int stars;
+        private int watchers;
+        private int forks;
+        private int openIssues;
+        private int closedIssues;
+        private String githubUrl;
+        private String readmeUrl;
+    }
+}

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/dto/RespResponseDTO.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/dto/RespResponseDTO.java
@@ -1,4 +1,0 @@
-package com.chungang.capstone.openstep.domain.Repo.dto;
-
-public class RespResponseDTO {
-}

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/entity/Repo.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/entity/Repo.java
@@ -25,15 +25,23 @@ public class Repo extends BaseEntity {
 
     private String repoName;
 
+    private String ownerName;
+
     private String description;
 
     private String language;
 
     private int stars;
+    private int watchers;
+    private int forks;
+    private int openIssues;
+    private int closedIssues;
 
     private String githubUrl;
 
-    private LocalDateTime updatedAt;
+    private String readmeUrl;
+
+    private LocalDateTime lastGithubUpdate;
 
     @OneToMany(mappedBy = "repo", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Issue> issues = new ArrayList<>();
@@ -41,3 +49,4 @@ public class Repo extends BaseEntity {
     @OneToMany(mappedBy = "repo", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Bookmark> bookmarks = new ArrayList<>();
 }
+

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/repository/RepoRepository.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/repository/RepoRepository.java
@@ -3,6 +3,9 @@ package com.chungang.capstone.openstep.domain.Repo.repository;
 import com.chungang.capstone.openstep.domain.Repo.entity.Repo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RepoRepository extends JpaRepository<Repo, Long> {
+import java.util.List;
 
+public interface RepoRepository extends JpaRepository<Repo, Long> {
+    List<Repo> findTop10ByOrderByStarsDesc();
 }
+

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/repository/RepoRepository.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/repository/RepoRepository.java
@@ -4,8 +4,10 @@ import com.chungang.capstone.openstep.domain.Repo.entity.Repo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface RepoRepository extends JpaRepository<Repo, Long> {
     List<Repo> findTop10ByOrderByStarsDesc();
+    Optional<Repo> findByGithubUrl(String githubUrl);
 }
 

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/GitHubGraphQLService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/GitHubGraphQLService.java
@@ -1,0 +1,71 @@
+package com.chungang.capstone.openstep.domain.Repo.service;
+
+import com.chungang.capstone.openstep.domain.Repo.dto.GitHubGraphQLRequest;
+import com.chungang.capstone.openstep.domain.Repo.dto.GitHubRepoResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GitHubGraphQLService {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${github.token}")
+    private String githubToken;
+
+    private static final String GITHUB_GRAPHQL_URL = "https://api.github.com/graphql";
+
+    public GitHubRepoResponse fetchTrendingRepositories() {
+        String query = """
+        {
+          search(query: "stars:>10000 sort:stars-desc", type: REPOSITORY, first: 10) {
+            edges {
+              node {
+                ... on Repository {
+                  name
+                  description
+                  url
+                  stargazerCount
+                  primaryLanguage {
+                    name
+                  }
+                  owner {
+                    login
+                  }
+                }
+              }
+            }
+          }
+        }
+        """;
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(githubToken);
+
+        GitHubGraphQLRequest requestBody = new GitHubGraphQLRequest(query);
+        HttpEntity<GitHubGraphQLRequest> request = new HttpEntity<>(requestBody, headers);
+
+        try {
+            ResponseEntity<GitHubRepoResponse> response = restTemplate.exchange(
+                    GITHUB_GRAPHQL_URL,
+                    HttpMethod.POST,
+                    request,
+                    GitHubRepoResponse.class
+            );
+
+            log.info("GitHub 응답 성공: {}", response.getBody());
+            return response.getBody();
+
+        } catch (Exception e) {
+            log.error("GitHub GraphQL 호출 실패", e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/GitHubGraphQLService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/GitHubGraphQLService.java
@@ -38,12 +38,27 @@ public class GitHubGraphQLService {
                   owner {
                     login
                   }
+                  forkCount
+                  openIssues: issues(states: OPEN) {
+                    totalCount
+                  }
+                  closedIssues: issues(states: CLOSED) {
+                    totalCount
+                  }
+                  goodFirstIssue: issues(first: 1) {
+                    totalCount
+                  }
+                  watchers {
+                    totalCount
+                  }
+                  updatedAt
                 }
               }
             }
           }
         }
         """;
+
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoQueryService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoQueryService.java
@@ -9,6 +9,8 @@ import com.chungang.capstone.openstep.domain.Repo.converter.RepoConverter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -31,12 +33,11 @@ public class RepoQueryService {
 
         List<Repo> repos = gitHubRepoResponse.getData().getSearch().getEdges()
                 .stream()
-                .map(edge -> saveIfNotExists(edge.getNode()))
+                .map(edge -> edge.getNode())
+                //.filter(node -> node.getStargazerCount() > 10000) // 별점 1,000 이상인 레포지토리만 필터링
+                .filter(node -> node.getOpenIssuesCount() > 0 && node.getGoodFirstIssueCount() > 0) // 오픈 이슈가 1개 이상이고, goodFirstIssue가 1개 이상인 레포지토리만 필터링
+                .map(this::saveIfNotExists)
                 .collect(Collectors.toList());
-
-
-        // DB 저장
-        // repoRepository.saveAll(repos);
 
         return repos;
     }
@@ -54,6 +55,12 @@ public class RepoQueryService {
                 .stars(node.getStargazerCount())
                 .githubUrl(node.getUrl())
                 .ownerName(node.getOwner() != null ? node.getOwner().getLogin() : null)
+                .forks(node.getForkCount() != null ? node.getForkCount() : 0)
+                .openIssues(node.getOpenIssues() != null ? node.getOpenIssues().getTotalCount() : 0)
+                .closedIssues(node.getClosedIssues() != null ? node.getClosedIssues().getTotalCount() : 0)
+                .watchers(node.getWatchers() != null ? node.getWatchers().getTotalCount() : 0)
+                .watchers(node.getWatchersCount())
+                .lastGithubUpdate(node.getUpdatedAt() != null ? OffsetDateTime.parse(node.getUpdatedAt()).toLocalDateTime() : null)
                 .build();
     }
 

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoQueryService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoQueryService.java
@@ -1,4 +1,26 @@
 package com.chungang.capstone.openstep.domain.Repo.service;
 
+import com.chungang.capstone.openstep.domain.Repo.entity.Repo;
+import com.chungang.capstone.openstep.domain.Repo.repository.RepoRepository;
+import com.chungang.capstone.openstep.global.apiPayload.code.status.ErrorStatus;
+import com.chungang.capstone.openstep.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
 public class RepoQueryService {
+
+    private final RepoRepository repoRepository;
+
+    public List<Repo> getTrendingRepos() {
+        return repoRepository.findTop10ByOrderByStarsDesc();
+    }
+
+    public Repo getRepoById(Long repoId) {
+        return repoRepository.findById(repoId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.REPO_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoQueryService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoQueryService.java
@@ -1,26 +1,65 @@
 package com.chungang.capstone.openstep.domain.Repo.service;
 
+import com.chungang.capstone.openstep.domain.Repo.dto.RepoResponseDTO;
+import com.chungang.capstone.openstep.domain.Repo.dto.GitHubRepoResponse;
+import com.chungang.capstone.openstep.domain.Repo.dto.GitHubRepoResponse.Node;
 import com.chungang.capstone.openstep.domain.Repo.entity.Repo;
 import com.chungang.capstone.openstep.domain.Repo.repository.RepoRepository;
-import com.chungang.capstone.openstep.global.apiPayload.code.status.ErrorStatus;
-import com.chungang.capstone.openstep.global.apiPayload.exception.GeneralException;
+import com.chungang.capstone.openstep.domain.Repo.converter.RepoConverter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class RepoQueryService {
 
     private final RepoRepository repoRepository;
+    private final GitHubGraphQLService gitHubGraphQLService;
 
     public List<Repo> getTrendingRepos() {
-        return repoRepository.findTop10ByOrderByStarsDesc();
+        GitHubRepoResponse gitHubRepoResponse = gitHubGraphQLService.fetchTrendingRepositories();
+
+        if (gitHubRepoResponse == null ||
+                gitHubRepoResponse.getData() == null ||
+                gitHubRepoResponse.getData().getSearch() == null ||
+                gitHubRepoResponse.getData().getSearch().getEdges() == null) {
+            throw new IllegalStateException("GitHub 응답 파싱 실패: null 필드 존재");
+        }
+
+        List<Repo> repos = gitHubRepoResponse.getData().getSearch().getEdges()
+                .stream()
+                .map(edge -> saveIfNotExists(edge.getNode()))
+                .collect(Collectors.toList());
+
+
+        // DB 저장
+        // repoRepository.saveAll(repos);
+
+        return repos;
     }
+
+    private Repo saveIfNotExists(Node node) {
+        return repoRepository.findByGithubUrl(node.getUrl())
+                .orElseGet(() -> repoRepository.save(toRepoEntity(node)));
+    }
+
+    private Repo toRepoEntity(Node node) {
+        return Repo.builder()
+                .repoName(node.getName())
+                .description(node.getDescription())
+                .language(node.getPrimaryLanguage() != null ? node.getPrimaryLanguage().getName() : null)
+                .stars(node.getStargazerCount())
+                .githubUrl(node.getUrl())
+                .ownerName(node.getOwner() != null ? node.getOwner().getLogin() : null)
+                .build();
+    }
+
 
     public Repo getRepoById(Long repoId) {
         return repoRepository.findById(repoId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.REPO_NOT_FOUND));
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 레포지토리입니다."));
     }
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoQueryService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoQueryService.java
@@ -6,6 +6,8 @@ import com.chungang.capstone.openstep.domain.Repo.dto.GitHubRepoResponse.Node;
 import com.chungang.capstone.openstep.domain.Repo.entity.Repo;
 import com.chungang.capstone.openstep.domain.Repo.repository.RepoRepository;
 import com.chungang.capstone.openstep.domain.Repo.converter.RepoConverter;
+import com.chungang.capstone.openstep.global.apiPayload.code.status.ErrorStatus;
+import com.chungang.capstone.openstep.global.apiPayload.exception.handler.RepoHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -67,6 +69,6 @@ public class RepoQueryService {
 
     public Repo getRepoById(Long repoId) {
         return repoRepository.findById(repoId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 레포지토리입니다."));
+                .orElseThrow(() -> new RepoHandler(ErrorStatus.REPO_NOT_FOUND));
     }
 }

--- a/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/ErrorStatus.java
@@ -23,8 +23,10 @@ public enum ErrorStatus implements BaseErrorCode {
     // 회원 관련 에러 1000
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER_1001", "사용자가 없습니다."),
     MEMBER_NAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER_1002", "이름입력은 필수 입니다."),
-    MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBER_1003", "이미 존재하는 유저입니다.");
+    MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBER_1003", "이미 존재하는 유저입니다."),
 
+    // 레포지토리 관련 에러 2000
+    REPO_NOT_FOUND(HttpStatus.NOT_FOUND, "REPO_2001", "존재하지 않는 레포지토리입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/ErrorStatus.java
@@ -28,6 +28,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 레포지토리 관련 에러 2000
     REPO_NOT_FOUND(HttpStatus.NOT_FOUND, "REPO_2001", "존재하지 않는 레포지토리입니다.");
 
+
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/SuccessStatus.java
@@ -20,7 +20,11 @@ public enum SuccessStatus implements BaseCode {
     USER_REGISTER_OK(HttpStatus.OK, "AUTH2000", "회원 가입이 완료되었습니다."),
 
     // 유저 관련 응답
-    MEMBER_OK(HttpStatus.OK, "MEMBER_1000", "성공입니다.");
+    MEMBER_OK(HttpStatus.OK, "MEMBER_1000", "성공입니다."),
+
+    // 레포지토리 관련 응답
+    REPO_GET_TRENDING_OK(HttpStatus.OK, "REPO_2001", "트렌딩 레포지토리 리스트를 성공적으로 조회하였습니다."),
+    REPO_GET_DETAIL_OK(HttpStatus.OK, "REPO_2002", "레포지토리 상세 정보를 성공적으로 조회하였습니다.");
 
 
 

--- a/src/main/java/com/chungang/capstone/openstep/global/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/apiPayload/exception/ExceptionAdvice.java
@@ -1,0 +1,120 @@
+package com.chungang.capstone.openstep.global.apiPayload.exception;
+
+import com.chungang.capstone.openstep.global.apiPayload.ApiResponse;
+import com.chungang.capstone.openstep.global.apiPayload.code.ErrorReasonDTO;
+import com.chungang.capstone.openstep.global.apiPayload.code.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(constraintViolation -> constraintViolation.getMessage())
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY,request);
+    }
+
+
+    //@org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e, HttpHeaders headers, HttpStatus status, WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors().stream()
+                .forEach(fieldError -> {
+                    String fieldName = fieldError.getField();
+                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                    errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+                });
+
+        return handleExceptionInternalArgs(e,HttpHeaders.EMPTY, ErrorStatus.valueOf("_BAD_REQUEST"),request,errors);
+    }
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(),request, e.getMessage());
+    }
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+        ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException,errorReasonHttpStatus,null,request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDTO reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+
+        ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(),reason.getMessage(),null);
+//        e.printStackTrace();
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+}

--- a/src/main/java/com/chungang/capstone/openstep/global/apiPayload/exception/handler/RepoHandler.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/apiPayload/exception/handler/RepoHandler.java
@@ -1,0 +1,12 @@
+package com.chungang.capstone.openstep.global.apiPayload.exception.handler;
+
+import com.chungang.capstone.openstep.global.apiPayload.code.BaseErrorCode;
+import com.chungang.capstone.openstep.global.apiPayload.exception.GeneralException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+public class RepoHandler extends GeneralException {
+    public RepoHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/chungang/capstone/openstep/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/config/RestTemplateConfig.java
@@ -1,0 +1,13 @@
+package com.chungang.capstone.openstep.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/chungang/capstone/openstep/global/config/SecurityConfig.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/config/SecurityConfig.java
@@ -38,6 +38,9 @@ public class SecurityConfig {
                                 // Member 관련 접근
                                 .requestMatchers("/member/register", "/member/login/kakao", "/member/login/naver", "/member/login/email","/member/refresh").permitAll()
 
+                                // Repo 관련 접근
+                                .requestMatchers("/repo/trending", "/repo/{repo-id}").permitAll()
+
                                 // 기타 관련 접근
                                 .requestMatchers("/example/**").permitAll()
                                 .requestMatchers("/", "/api-docs/**", "/api-docs/swagger-config/*", "/swagger-ui/*", "/swagger-ui/**", "/v3/api-docs/**").permitAll()


### PR DESCRIPTION
## #️⃣연관된 이슈
> #33 

## 📝작업 내용
> - GitHub GraphQL API를 활용하여 트렌딩 레포지토리 조회 기능 구현
> - 특정 레포지토리 상세 조회 기능 구현
> - 오픈 이슈 및 good first issue가 존재하는 레포지토리만 필터링

## 🔎코드 설명 및 참고 사항
> GraphQL 쿼리에서 openIssues, closedIssues, watchers, goodFirstIssues 등 세부 정보 조회

## 💬리뷰 요구사항
>
