### PR TITLE
Feat: 트렌딩 이슈 리스트 조회 API 기능 구현

### DIFF
--- a/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/GitHubGraphQLRequest.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/GitHubGraphQLRequest.java
@@ -1,4 +1,4 @@
-package com.chungang.capstone.openstep.domain.Repo.dto;
+package com.chungang.capstone.openstep.domain.Github.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/GitHubIssueResponse.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/GitHubIssueResponse.java
@@ -1,0 +1,54 @@
+package com.chungang.capstone.openstep.domain.Github.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class GitHubIssueResponse {
+    private Data data;
+
+    @Getter
+    public static class Data {
+        private Repository repository;
+    }
+
+    @Getter
+    public static class Repository {
+        private String name;
+        private Issues issues;
+    }
+
+    @Getter
+    public static class Issues {
+        private List<IssueNode> nodes;
+    }
+
+    @Getter
+    public static class IssueNode {
+        private String title;
+        private String body;
+        private String url;
+        private String createdAt;
+        private String updatedAt;
+        private Author author;
+        private Labels labels;
+    }
+
+    @Getter
+    public static class Author {
+        private String login;
+    }
+
+    @Getter
+    public static class Labels {
+        private List<LabelNode> nodes;
+    }
+
+    @Getter
+    public static class LabelNode {
+        private String name;
+    }
+
+
+}

--- a/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/GitHubRepoResponse.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/GitHubRepoResponse.java
@@ -1,4 +1,4 @@
-package com.chungang.capstone.openstep.domain.Repo.dto;
+package com.chungang.capstone.openstep.domain.Github.dto;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/chungang/capstone/openstep/domain/Github/service/GitHubGraphQLService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Github/service/GitHubGraphQLService.java
@@ -1,7 +1,8 @@
-package com.chungang.capstone.openstep.domain.Repo.service;
+package com.chungang.capstone.openstep.domain.Github.service;
 
-import com.chungang.capstone.openstep.domain.Repo.dto.GitHubGraphQLRequest;
-import com.chungang.capstone.openstep.domain.Repo.dto.GitHubRepoResponse;
+import com.chungang.capstone.openstep.domain.Github.dto.GitHubGraphQLRequest;
+import com.chungang.capstone.openstep.domain.Github.dto.GitHubIssueResponse;
+import com.chungang.capstone.openstep.domain.Github.dto.GitHubRepoResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,10 +22,11 @@ public class GitHubGraphQLService {
 
     private static final String GITHUB_GRAPHQL_URL = "https://api.github.com/graphql";
 
+    // Repo 정보 조회
     public GitHubRepoResponse fetchTrendingRepositories() {
         String query = """
         {
-          search(query: "stars:>10000 sort:stars-desc", type: REPOSITORY, first: 10) {
+          search(query: "stars:>10000 sort:stars-desc", type: REPOSITORY, first: 5) {
             edges {
               node {
                 ... on Repository {
@@ -59,7 +61,6 @@ public class GitHubGraphQLService {
         }
         """;
 
-
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.setBearerAuth(githubToken);
@@ -83,4 +84,46 @@ public class GitHubGraphQLService {
             return null;
         }
     }
+
+    // Issue 정보 조회
+    public GitHubIssueResponse fetchIssuesByRepo(String owner, String name) {
+        String query = String.format("""
+    {
+      repository(owner: "%s", name: "%s") {
+        name
+        issues(first: 10, orderBy: {field: UPDATED_AT, direction: DESC}) {
+          nodes {
+            title
+            body
+            url
+            createdAt
+            updatedAt
+            author { login }
+            labels(first: 10) {
+              nodes { name }
+            }
+          }
+        }
+      }
+    }
+    """, owner, name);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(githubToken);
+
+        HttpEntity<GitHubGraphQLRequest> request = new HttpEntity<>(new GitHubGraphQLRequest(query), headers);
+
+        try {
+            ResponseEntity<GitHubIssueResponse> response = restTemplate.exchange(
+                    GITHUB_GRAPHQL_URL, HttpMethod.POST, request, GitHubIssueResponse.class
+            );
+            return response.getBody();
+        } catch (Exception e) {
+            log.error("GitHub 이슈 조회 실패: {} / {}", owner, name, e);
+            return null;
+        }
+    }
+
+
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/controller/IssueController.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/controller/IssueController.java
@@ -1,4 +1,49 @@
 package com.chungang.capstone.openstep.domain.Issue.controller;
 
+import com.chungang.capstone.openstep.domain.Issue.service.IssueQueryService;
+import com.chungang.capstone.openstep.global.apiPayload.code.status.SuccessStatus;
+import com.chungang.capstone.openstep.global.apiPayload.ApiResponse;
+import com.chungang.capstone.openstep.domain.Issue.converter.IssueConverter;
+import com.chungang.capstone.openstep.domain.Issue.dto.IssueResponseDTO;
+import com.chungang.capstone.openstep.domain.Issue.entity.Issue;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.parameters.P;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/issues")
+@Tag(name = "이슈 API", description = "GitHub 이슈 관련 API입니다.")
 public class IssueController {
+
+    private final IssueQueryService issueQueryService;
+
+    // 트렌딩 이슈 목록 조회 API
+    @GetMapping("/trending")
+    @Operation(summary = "트렌딩 issue 조회 API", description = "현재 인기 있는 트렌딩한 오픈소스 이슈를 조회합니다.")
+    public ApiResponse<List<IssueResponseDTO.TrendingIssueDTO>> getTrendingIssues() {
+        List<IssueResponseDTO.TrendingIssueDTO> issues = issueQueryService.getTrendingIssues();
+        return ApiResponse.onSuccess(SuccessStatus.ISSUE_GET_TRENDING_OK, issues);
+    }
+
+    // 특정 이슈 상세 조회
+//    @GetMapping("/{issue-id}")
+//    @Operation(summary = "특정 이슈 상세 조회 API", description = "특정 오픈소스 이슈의 상세 정보를 조회합니다.")
+//    public ApiResponse<IssueResponseDTO.IssueDetailDTO> getIssueDetail(@PathVariable("issue-id") Long issueId) {
+//        Issue issue = issueQueryService.getIssueById(issueId);
+//        return ApiResponse.onSuccess(SuccessStatus.ISSUE_GET_DETAIL_OK, IssueConverter.toIssueDetailDTO(issue));
+//    }
+
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/converter/IssueConverter.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/converter/IssueConverter.java
@@ -1,4 +1,26 @@
 package com.chungang.capstone.openstep.domain.Issue.converter;
 
+import com.chungang.capstone.openstep.domain.Github.dto.GitHubIssueResponse;
+import com.chungang.capstone.openstep.domain.Issue.dto.IssueResponseDTO;
+import com.chungang.capstone.openstep.domain.Issue.entity.Issue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class IssueConverter {
+    public static List<IssueResponseDTO.TrendingIssueDTO> toTrendingDTOs(List<Issue> issues) {
+        return issues.stream()
+                .map(issue -> IssueResponseDTO.TrendingIssueDTO.builder()
+                        .title(issue.getTitle())
+                        .body(issue.getBody())
+                        .url(issue.getGithubUrl())
+                        .createdAt(issue.getCreatedAt() != null ? issue.getCreatedAt().toString() : null)
+                        .updatedAt(issue.getUpdatedAt() != null ? issue.getUpdatedAt().toString() : null)
+                        .author(issue.getAuthor())
+                        .labels(issue.getLabels())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/dto/IssueResponseDTO.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/dto/IssueResponseDTO.java
@@ -1,4 +1,25 @@
 package com.chungang.capstone.openstep.domain.Issue.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
 public class IssueResponseDTO {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class TrendingIssueDTO {
+        private String title;
+        private String body;
+        private String url;
+        private String createdAt;
+        private String updatedAt;
+        private String author;
+        private List<String> labels;
+    }
+
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/entity/Issue.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/entity/Issue.java
@@ -27,16 +27,30 @@ public class Issue extends BaseEntity {
     @JoinColumn(name = "repo_id", nullable = false)
     private Repo repo;
 
+    @Column(columnDefinition = "varchar(500)", length = 500)
     private String title;
 
     @Column(columnDefinition = "TEXT")
     private String body;
 
+    @Column(unique = true)
     private String githubUrl;
 
     private String status; // OPEN, CLOSED 등
 
+    private String author;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "issue_labels", joinColumns = @JoinColumn(name = "issue_id"))
+    @Column(name = "label")
+    private List<String> labels = new ArrayList<>();
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
     @OneToMany(mappedBy = "issue", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Task> tasks = new ArrayList<>();
 }
+
 

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/repository/IssueRepository.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/repository/IssueRepository.java
@@ -3,5 +3,8 @@ package com.chungang.capstone.openstep.domain.Issue.repository;
 import com.chungang.capstone.openstep.domain.Issue.entity.Issue;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface IssueRepository extends JpaRepository<Issue, Long> {
+    Optional<Issue> findByGithubUrl(String githubUrl);
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueQueryService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueQueryService.java
@@ -1,4 +1,102 @@
 package com.chungang.capstone.openstep.domain.Issue.service;
 
+import com.chungang.capstone.openstep.domain.Github.dto.GitHubIssueResponse;
+import com.chungang.capstone.openstep.domain.Github.dto.GitHubIssueResponse.IssueNode;
+import com.chungang.capstone.openstep.domain.Github.dto.GitHubRepoResponse;
+import com.chungang.capstone.openstep.domain.Issue.entity.Issue;
+import com.chungang.capstone.openstep.domain.Issue.repository.IssueRepository;
+import com.chungang.capstone.openstep.domain.Issue.dto.IssueResponseDTO;
+import com.chungang.capstone.openstep.domain.Github.service.GitHubGraphQLService;
+import com.chungang.capstone.openstep.domain.Issue.converter.IssueConverter;
+import com.chungang.capstone.openstep.domain.Repo.entity.Repo;
+import com.chungang.capstone.openstep.domain.Repo.repository.RepoRepository;
+import com.chungang.capstone.openstep.global.apiPayload.code.status.ErrorStatus;
+import com.chungang.capstone.openstep.global.apiPayload.exception.handler.IssueHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
 public class IssueQueryService {
+
+    private final IssueRepository issueRepository;
+    private final GitHubGraphQLService gitHubGraphQLService;
+    private final RepoRepository repoRepository;
+
+    public List<IssueResponseDTO.TrendingIssueDTO> getTrendingIssues() {
+        List<Repo> repos = repoRepository.findAll(); // DB에 있는 5개 레포 사용
+        List<Issue> allIssues = new ArrayList<>();
+
+        for (Repo repo : repos) {
+            String owner = repo.getOwnerName();
+            String repoName = repo.getRepoName();
+
+            GitHubIssueResponse issueResponse = gitHubGraphQLService.fetchIssuesByRepo(owner, repoName);
+
+            if (issueResponse != null && issueResponse.getData().getRepository() != null) {
+                var issueNodes = issueResponse.getData().getRepository().getIssues().getNodes();
+
+                List<Issue> savedIssues = issueNodes.stream()
+                        .map(node -> saveIfNotExists(node, repo))
+                        .filter(Objects::nonNull)
+                        .toList();
+
+                allIssues.addAll(savedIssues);
+                System.out.println("📌 " + owner + "/" + repoName + " 의 이슈 수: " + issueNodes.size());
+            }
+        }
+
+        return IssueConverter.toTrendingDTOs(allIssues);
+    }
+
+    private Issue saveIfNotExists(GitHubIssueResponse.IssueNode node, Repo repo) {
+        if (node.getTitle() == null || node.getTitle().length() < 1) return null;
+
+        String rawBody = node.getBody();
+        String body = (rawBody == null || rawBody.length() < 20 || !rawBody.matches(".*[가-힣a-zA-Z].*"))
+                ? "내용 없음"
+                : rawBody;
+
+        List<String> labels = node.getLabels() != null
+                ? node.getLabels().getNodes().stream().map(GitHubIssueResponse.LabelNode::getName).toList()
+                : Collections.emptyList();
+
+        boolean isGoodLabel = labels.stream().anyMatch(label ->
+                label.toLowerCase().contains("good first issue") || label.toLowerCase().contains("help wanted"));
+
+        if (!isGoodLabel) return null;
+
+        return issueRepository.findByGithubUrl(node.getUrl())
+                .orElseGet(() -> issueRepository.save(toIssueEntity(node, repo, body)));
+    }
+
+
+    private Issue toIssueEntity(GitHubIssueResponse.IssueNode node, Repo repo, String body) {
+        return Issue.builder()
+                .repo(repo)
+                .title(node.getTitle())
+                .body(body)
+                .githubUrl(node.getUrl())
+                .author(node.getAuthor() != null ? node.getAuthor().getLogin() : "unknown")
+                .labels(node.getLabels() != null
+                        ? node.getLabels().getNodes().stream().map(GitHubIssueResponse.LabelNode::getName).toList()
+                        : Collections.emptyList())
+                .createdAt(node.getCreatedAt() != null ? OffsetDateTime.parse(node.getCreatedAt()).toLocalDateTime() : null)
+                .updatedAt(node.getUpdatedAt() != null ? OffsetDateTime.parse(node.getUpdatedAt()).toLocalDateTime() : null)
+                .status("OPEN")
+                .build();
+    }
+
+
+    public Issue getIssueById(Long issueId) {
+        return issueRepository.findById(issueId)
+                .orElseThrow(() -> new IssueHandler(ErrorStatus.ISSUE_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/repository/RepoRepository.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/repository/RepoRepository.java
@@ -9,5 +9,6 @@ import java.util.Optional;
 public interface RepoRepository extends JpaRepository<Repo, Long> {
     List<Repo> findTop10ByOrderByStarsDesc();
     Optional<Repo> findByGithubUrl(String githubUrl);
+    Optional<Repo> findByRepoName(String name);
 }
 

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoQueryService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoQueryService.java
@@ -1,17 +1,15 @@
 package com.chungang.capstone.openstep.domain.Repo.service;
 
-import com.chungang.capstone.openstep.domain.Repo.dto.RepoResponseDTO;
-import com.chungang.capstone.openstep.domain.Repo.dto.GitHubRepoResponse;
-import com.chungang.capstone.openstep.domain.Repo.dto.GitHubRepoResponse.Node;
+import com.chungang.capstone.openstep.domain.Github.service.GitHubGraphQLService;
+import com.chungang.capstone.openstep.domain.Github.dto.GitHubRepoResponse;
+import com.chungang.capstone.openstep.domain.Github.dto.GitHubRepoResponse.Node;
 import com.chungang.capstone.openstep.domain.Repo.entity.Repo;
 import com.chungang.capstone.openstep.domain.Repo.repository.RepoRepository;
-import com.chungang.capstone.openstep.domain.Repo.converter.RepoConverter;
 import com.chungang.capstone.openstep.global.apiPayload.code.status.ErrorStatus;
 import com.chungang.capstone.openstep.global.apiPayload.exception.handler.RepoHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/ErrorStatus.java
@@ -29,8 +29,10 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBER_1003", "이미 존재하는 유저입니다."),
 
     // 레포지토리 관련 에러 2000
-    REPO_NOT_FOUND(HttpStatus.NOT_FOUND, "REPO_2001", "존재하지 않는 레포지토리입니다.");
+    REPO_NOT_FOUND(HttpStatus.NOT_FOUND, "REPO_2001", "존재하지 않는 레포지토리입니다."),
 
+    // 이슈 관련 에러 3000
+    ISSUE_NOT_FOUND(HttpStatus.NOT_FOUND, "ISSUE_3001", "존재하지 않는 이슈입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/SuccessStatus.java
@@ -22,9 +22,10 @@ public enum SuccessStatus implements BaseCode {
 
     // 레포지토리 관련 응답
     REPO_GET_TRENDING_OK(HttpStatus.OK, "REPO_2001", "트렌딩 레포지토리 리스트를 성공적으로 조회하였습니다."),
-    REPO_GET_DETAIL_OK(HttpStatus.OK, "REPO_2002", "레포지토리 상세 정보를 성공적으로 조회하였습니다.");
+    REPO_GET_DETAIL_OK(HttpStatus.OK, "REPO_2002", "레포지토리 상세 정보를 성공적으로 조회하였습니다."),
 
-
+    // 이슈 관련 응답
+    ISSUE_GET_TRENDING_OK(HttpStatus.OK, "ISSUE_3001", "트렌딩 이슈 리스트를 성공적으로 조회하였습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/chungang/capstone/openstep/global/apiPayload/exception/handler/IssueHandler.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/apiPayload/exception/handler/IssueHandler.java
@@ -1,0 +1,10 @@
+package com.chungang.capstone.openstep.global.apiPayload.exception.handler;
+
+import com.chungang.capstone.openstep.global.apiPayload.code.BaseErrorCode;
+import com.chungang.capstone.openstep.global.apiPayload.exception.GeneralException;
+
+public class IssueHandler extends GeneralException {
+    public IssueHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/chungang/capstone/openstep/global/config/SecurityConfig.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/config/SecurityConfig.java
@@ -42,6 +42,9 @@ public class SecurityConfig {
                                 // Repo 관련 접근
                                 .requestMatchers("/repo/trending", "/repo/{repo-id}").permitAll()
 
+                                // Issue 관련 접근
+                                .requestMatchers("/issues/trending", "/issues/{issue-id}").permitAll()
+
                                 // 기타 관련 접근
                                 .requestMatchers("/example/**").permitAll()
                                 .requestMatchers("/", "/api-docs/**", "/api-docs/swagger-config/*", "/swagger-ui/*", "/swagger-ui/**", "/v3/api-docs/**").permitAll()


### PR DESCRIPTION
## #️⃣연관된 이슈
> #41
## 📝작업 내용
> 트렌딩 이슈 리스트 조회 API 기능 구현

## 🔎코드 설명 및 참고 사항
> - 트렌딩 이슈 리스트 조회 API 기능 구현완료
> - 트렌딩 레포지토리의 이슈들 중 good first issue, help wanted 의 태그가 있는 이슈 위주로 조회
> - 현재 이슈의 body가 매우 길어서 '내용 없음'으로 저장한 상태. 추후 요약 기능 도입하여 업데이트 예정

## 💬리뷰 요구사항
>
