### PR TITLE
Fix: GitHub OAuth 사용자 정보 요청 시 Accept 헤더 추가

### DIFF
--- a/src/main/java/com/chungang/capstone/openstep/domain/Member/service/GithubOauthService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Member/service/GithubOauthService.java
@@ -44,6 +44,8 @@ public class GithubOauthService {
 			code
 		);
 
+
+
 		ResponseEntity<GithubOAuthDTO.GithubOauthRes> response = restTemplate.postForEntity(
 			"https://github.com/login/oauth/access_token",
 			githubOAuthReq,
@@ -52,8 +54,10 @@ public class GithubOauthService {
 		return Objects.requireNonNull(response.getBody()).access_token();
 	}
 	public GithubOAuthDTO.GithubUserInfoRes getGithubUserByAccessToken(String accessToken) {
-		HttpHeaders headers=new HttpHeaders();
+		HttpHeaders headers = new HttpHeaders();
 		headers.setBearerAuth(accessToken);
+		headers.set("Accept", "application/json");
+
 		HttpEntity<Void> request=new HttpEntity<>(headers);
 		//access token을 이용해 사용자 정보를 요청하는 API 호출
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #32 

## 📝작업 내용
> GitHub OAuth 사용자 정보 요청 시 Accept 헤더 추가

## 🔎코드 설명 및 참고 사항
> GitHub 사용자 정보 요청에 Accept: application/json 헤더 추가

## 💬리뷰 요구사항
>
