### PR TITLE
Fix: GitHub OAuth 사용자 정보 요청 시 Accept 헤더 추가

### DIFF
--- a/src/main/java/com/chungang/capstone/openstep/domain/Member/service/GithubOauthService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Member/service/GithubOauthService.java
@@ -43,8 +43,9 @@ public class GithubOauthService {
 			clientSecret,
 			code
 		);
-
-
+		HttpHeaders headers = new HttpHeaders();
+		headers.set("Accept", "application/json");
+		HttpEntity<GithubOAuthDTO.GithubOAuthReq> request = new HttpEntity<>(githubOAuthReq, headers);
 
 		ResponseEntity<GithubOAuthDTO.GithubOauthRes> response = restTemplate.postForEntity(
 			"https://github.com/login/oauth/access_token",


### PR DESCRIPTION
## #️⃣연관된 이슈
> #32 

## 📝작업 내용
> GitHub OAuth 사용자 정보 요청 시 Accept 헤더 추가

## 🔎코드 설명 및 참고 사항
> GitHub OAuth 사용자 정보 요청 시 Accept 헤더 추가

## 💬리뷰 요구사항
>
