### PR TITLE
Feat: 이메일 회원가입, 로그인, 로그아웃, 액세스 토큰 재할당 API 구현

### DIFF
--- a/src/main/java/com/chungang/capstone/openstep/domain/Member/controller/MemberController.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Member/controller/MemberController.java
@@ -2,12 +2,9 @@ package com.chungang.capstone.openstep.domain.Member.controller;
 
 import java.util.List;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.chungang.capstone.openstep.domain.Member.service.AuthService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
 
 import com.chungang.capstone.openstep.domain.Github.dto.PullRequestResponse;
 import com.chungang.capstone.openstep.domain.Github.service.GitHubGraphQLService;
@@ -31,9 +28,39 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MemberController {
 
+	private final AuthService authService;
 	private final MemberQueryService memberQueryService;
 	private final MemberCommandService memberCommandService;
 	private final GitHubGraphQLService gitHubGraphQLService;
+
+	@PostMapping("/sign_up")
+	@Operation(summary = "회원가입", description = "회원가입을 진행합니다.")
+	public ApiResponse<String> signUp(@Valid @RequestBody MemberRequestDTO.MemberSignUpRequestDTO request) {
+		String response = authService.signUp(request);
+		return ApiResponse.onSuccess(SuccessStatus.MEMBER_SIGN_UP_OK, response);
+	}
+
+	@PostMapping("/login")
+	@Operation(summary = "로그인", description = "로그인을 진행합니다.")
+	public ApiResponse<MemberResponseDTO.MemberTokenResponseDTO> login(@Valid @RequestBody MemberRequestDTO.MemberLoginRequestDTO request) {
+		MemberResponseDTO.MemberTokenResponseDTO response = authService.login(request);
+		return ApiResponse.onSuccess(SuccessStatus.MEMBER_LOGIN_OK, response);
+	}
+
+	@PostMapping("/logout")
+	@Operation(summary = "로그아웃")
+	public ApiResponse<String> logout(@Valid @RequestBody MemberRequestDTO.refreshRequestDTO request) {
+		String response = authService.logout(request);
+		return ApiResponse.onSuccess(SuccessStatus.MEMBER_LOGOUT_OK, response);
+	}
+
+	@PostMapping("/refresh")
+	@Operation(summary = "액세스 토큰 재할당")
+	public ApiResponse<MemberResponseDTO.TokenRefreshResponseDTO> refresh(@Valid @RequestBody MemberRequestDTO.refreshRequestDTO request) {
+		MemberResponseDTO.TokenRefreshResponseDTO response = authService.refresh(request);
+		return ApiResponse.onSuccess(SuccessStatus.MEMBER_UPDATE_ACCESS_TOKEN_OK, response);
+	}
+
 
 	@Operation(summary = "관심사(domain) 조회 API", description = "사용자의 관심사(도메인)을 조회합니다.")
 	@GetMapping("/domains")

--- a/src/main/java/com/chungang/capstone/openstep/domain/Member/converter/MemberConverter.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Member/converter/MemberConverter.java
@@ -2,6 +2,7 @@ package com.chungang.capstone.openstep.domain.Member.converter;
 
 import java.util.List;
 
+import com.chungang.capstone.openstep.domain.Member.dto.MemberRequestDTO;
 import com.chungang.capstone.openstep.domain.Member.dto.MemberResponseDTO;
 import com.chungang.capstone.openstep.domain.Member.entity.Member;
 
@@ -26,4 +27,16 @@ public class MemberConverter {
 			.skills(skills)
 			.build();
 	}
+
+	// 이메일 회원가입용
+	public static Member toMember(MemberRequestDTO.MemberSignUpRequestDTO request, String password) {
+		Member member = Member.builder()
+				.email(request.email())
+				.password(password)
+				.nickname(request.nickname())
+				.githubId(request.githubId())
+				.build();
+		return member;
+	}
+
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Member/dto/MemberRequestDTO.java
@@ -1,5 +1,15 @@
 package com.chungang.capstone.openstep.domain.Member.dto;
 
+import com.chungang.capstone.openstep.global.apiPayload.exception.handler.MemberHandler;
+import com.chungang.capstone.openstep.global.apiPayload.code.status.ErrorStatus;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+import java.time.LocalDate;
 import java.util.List;
 
 public class MemberRequestDTO {
@@ -10,4 +20,49 @@ public class MemberRequestDTO {
 	public record UpdateSkillsReq(
 		List<String> skills
 	){}
+
+	// 회원가입 요청 DTO
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+	@Builder
+	public record MemberSignUpRequestDTO(
+			String email,
+			String password,
+			String nickname,
+			String githubId) {
+
+		@JsonIgnore
+		public Boolean isCorrect() {
+			if (!email.matches("^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$")) {
+				throw new MemberHandler(ErrorStatus.MEMBER_WRONG_EMAIL);
+			}
+			if (!password.matches("^[a-zA-Z0-9@$!%*#?&]{8,}$")) {
+				throw new MemberHandler(ErrorStatus.MEMBER_WRONG_PASSWORD);
+			}
+			if (nickname.trim().isEmpty()) {
+				throw new MemberHandler(ErrorStatus.MEMBER_NAME_NOT_EXIST);
+			}
+			return true;
+		}
+	}
+
+	// 로그인 요청 DTO
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+	@Builder
+	public record MemberLoginRequestDTO(String email, String password) {
+		public UsernamePasswordAuthenticationToken toAuthentication() {
+			return new UsernamePasswordAuthenticationToken(email, password);
+		}
+	}
+
+	// refresh token 요청 DTO
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+	@Builder
+	public record refreshRequestDTO(
+			String refreshToken) {
+	}
+
+
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Member/dto/MemberResponseDTO.java
@@ -2,6 +2,7 @@ package com.chungang.capstone.openstep.domain.Member.dto;
 
 import java.util.List;
 
+import com.chungang.capstone.openstep.global.security.provider.TokenInfo;
 import com.fasterxml.classmate.AnnotationOverrides;
 
 import lombok.Builder;
@@ -29,5 +30,21 @@ public class MemberResponseDTO {
 	@Builder
 	public record Oauth2ResponseDTO(String redirectUrl) {}
 
+	@Builder
+	public record MemberTokenResponseDTO (
+			TokenInfo tokenInfo,
+			String email,
+			String nickname,
+			String githubId,
+			Long memberId) {
+	}
+
+	@Builder
+	public record TokenRefreshResponseDTO(
+			String accessToken,
+			String email,
+			String nickname,
+			String githubId,
+			Long memberId) {}
 
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Member/repository/MemberRepository.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Member/repository/MemberRepository.java
@@ -4,7 +4,14 @@ import com.chungang.capstone.openstep.domain.Member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 	Member findByGithubId(String githubId);
+
+	Boolean existsByEmail(String email);
+	Boolean existsByNickname(String nickname);
+	Optional<Member> findByEmail(String email);
+
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Member/service/AuthService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Member/service/AuthService.java
@@ -1,0 +1,163 @@
+package com.chungang.capstone.openstep.domain.Member.service;
+
+import com.chungang.capstone.openstep.global.apiPayload.exception.handler.MemberHandler;
+import com.chungang.capstone.openstep.domain.Member.dto.MemberResponseDTO;
+import com.chungang.capstone.openstep.domain.Member.dto.MemberRequestDTO;
+import com.chungang.capstone.openstep.domain.Member.converter.MemberConverter;
+import com.chungang.capstone.openstep.domain.Member.entity.Member;
+import com.chungang.capstone.openstep.domain.Member.repository.MemberRepository;
+import com.chungang.capstone.openstep.global.apiPayload.code.status.ErrorStatus;
+import com.chungang.capstone.openstep.global.security.provider.JwtTokenProvider;
+import com.chungang.capstone.openstep.global.security.provider.TokenInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Transactional
+    public String signUp(MemberRequestDTO.MemberSignUpRequestDTO request) {
+        // validation
+        // - 이메일, 닉네임, 비밀번호 적합한지 확인
+        // - 존재하는 닉네임/이메일인지 확인
+        request.isCorrect();
+        if (memberRepository.existsByEmail(request.email())
+                || memberRepository.existsByNickname(request.nickname())) {
+            throw new MemberHandler(ErrorStatus.MEMBER_ALREADY_EXISTS);
+        }
+
+        // business logic: dto 바탕으로 member entity 제작 및 저장
+        String encodedPassword = passwordEncoder.encode(request.password());
+        Member member = MemberConverter.toMember(request, encodedPassword);
+        memberRepository.save(member);
+
+        // response: 정상적으로 계정 생성되었음을 반환
+        return "정상적으로 가입되었습니다.";
+    }
+
+    @Transactional
+    public String checkEmailDuplication(String email) {
+        // validation: 이메일 형식 확인
+        if (!email.matches("^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$")) {
+            throw new MemberHandler(ErrorStatus.MEMBER_WRONG_EMAIL);
+        }
+
+        // business logic: 이메일 중복 확인
+        if (memberRepository.existsByEmail(email)) {
+            throw new MemberHandler(ErrorStatus.MEMBER_EMAIL_ALREADY_EXISTS);
+        }
+
+        // response: 사용가능 여부 반환
+        return "사용가능한 이메일입니다!";
+    }
+
+    @Transactional
+    public String checkNicknameDuplication(String nickname) {
+        // validation: 닉네임 형식 확인
+        if (nickname.trim().isEmpty()) {
+            throw new MemberHandler(ErrorStatus.MEMBER_NAME_NOT_EXIST);
+        }
+
+        // business logic: 닉네임 중복 확인
+        if (memberRepository.existsByNickname(nickname)) {
+            throw new MemberHandler(ErrorStatus.MEMBER_NICKNAME_ALREADY_EXISTS);
+        }
+
+        return "사용가능한 닉네임입니다!";
+    }
+
+
+    @Transactional
+    public MemberResponseDTO.MemberTokenResponseDTO login(MemberRequestDTO.MemberLoginRequestDTO request) {
+
+        try {
+            // 1. Login ID/PW를 기반으로 Authentication 객체 생성
+            UsernamePasswordAuthenticationToken authenticationToken = request.toAuthentication();
+
+            // 2. 비밀번호 체크
+            // loadUserByUsername method 실행됨
+            Authentication authentication = authenticationManagerBuilder.getObject()
+                    .authenticate(authenticationToken);
+
+            // 3. 인증 정보를 기반으로 JWT 토큰 생성
+            Member getMember = memberRepository.findByEmail(request.email()).orElseThrow();
+            TokenInfo tokenInfo = jwtTokenProvider.generateToken(authentication);
+
+            return MemberResponseDTO.MemberTokenResponseDTO.builder()
+                    .email(getMember.getEmail())
+                    .githubId(getMember.getGithubId())
+                    .nickname(getMember.getNickname())
+                    .tokenInfo(tokenInfo)
+                    .memberId(getMember.getMemberId())
+                    .build();
+        } catch (AuthenticationException e) {
+            throw new MemberHandler(ErrorStatus.MEMBER_LOGIN_FAIL);
+        }
+    }
+
+    @Transactional
+    public String logout(MemberRequestDTO.refreshRequestDTO request) {
+        String refreshToken = request.refreshToken();
+
+        // validation: 로그인 상태인지 확인, 정상 토큰인지 확인
+        if (redisTemplate.hasKey(refreshToken)) {
+            throw new MemberHandler(ErrorStatus.MEMBER_ALREADY_LOGGED_OUT);
+        }
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new MemberHandler(ErrorStatus.MEMBER_WRONG_TOKEN);
+        }
+
+        // business logic: 만료 날짜 설정 및 refresh token blacklist에 추가
+        Date expirationDate = jwtTokenProvider.getExpirationTimeFromToken(refreshToken);
+        long expirationTime = (expirationDate.getTime() - (new Date()).getTime()) / 1000;
+        redisTemplate.opsForValue().set(refreshToken, "blacklisted", expirationTime, TimeUnit.SECONDS);
+
+        return "로그아웃되었습니다.";
+    }
+
+    @Transactional
+    public MemberResponseDTO.TokenRefreshResponseDTO refresh(MemberRequestDTO.refreshRequestDTO request) {
+        String refreshToken = request.refreshToken();
+
+        // validation: 정상 토큰 확인 및 로그아웃한 유저인지 확인
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new MemberHandler(ErrorStatus.MEMBER_WRONG_TOKEN);
+        }
+        if (redisTemplate.hasKey(refreshToken)) {
+            throw new MemberHandler(ErrorStatus.MEMBER_ALREADY_LOGGED_OUT);
+        }
+
+        // business logic: access token 재할당
+        String userEmail = jwtTokenProvider.getUserEmailFromToken(refreshToken);
+        String newAccessToken = jwtTokenProvider.createAccessTokenByEmail(userEmail);
+        Member member = memberRepository.findByEmail(userEmail).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // response: 만들어진 토큰 반환
+        return MemberResponseDTO.TokenRefreshResponseDTO.builder()
+                .accessToken(newAccessToken)
+                .email(userEmail)
+                .githubId(member.getGithubId())
+                .nickname(member.getNickname())
+                .memberId(member.getMemberId())
+                .build();
+    }
+
+}

--- a/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/ErrorStatus.java
@@ -22,6 +22,13 @@ public enum ErrorStatus implements BaseErrorCode {
     AUTH_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "토큰이 만료되었습니다."),
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "토큰이 유효하지 않습니다."),
     INVALID_LOGIN_REQUEST(HttpStatus.UNAUTHORIZED, "AUTH_003", "올바른 아이디나 패스워드가 아닙니다."),
+    MEMBER_WRONG_EMAIL(HttpStatus.UNAUTHORIZED, "AUTH_004", "이메일이 잘못되었습니다."),
+    MEMBER_WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH_005", "비밀번호가 잘못되었습니다."),
+    MEMBER_EMAIL_ALREADY_EXISTS(HttpStatus.UNAUTHORIZED, "AUTH_006", "이미 존재하는 이메일입니다."),
+    MEMBER_NICKNAME_ALREADY_EXISTS(HttpStatus.UNAUTHORIZED, "AUTH_007", "이미 존재하는 닉네임입니다."),
+    MEMBER_LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "AUTH_008", "로그인에 실패했습니다."),
+    MEMBER_ALREADY_LOGGED_OUT(HttpStatus.UNAUTHORIZED, "AUTH_009", "이미 로그아웃된 계정입니다."),
+    MEMBER_WRONG_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_010", "잘못된 토큰입니다."),
 
     //GITHUB AUTH 관련
     GITHUB_AUTH_ERROR(HttpStatus.UNAUTHORIZED, "AUTH_004", "깃허브 인증에 실패했습니다."),

--- a/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/SuccessStatus.java
@@ -23,6 +23,10 @@ public enum SuccessStatus implements BaseCode {
     MEMBER_GET_SKILLS_OK(HttpStatus.OK, "MEMBER_1002", "유저 기술스택 조회에 성공하였습니다."),
     MEMBER_PATCH_INTERESTS_OK(HttpStatus.OK, "MEMBER_1003", "유저 관심분야 수정에 성공하였습니다."),
     MEMBER_PATCH_SKILLS_OK(HttpStatus.OK, "MEMBER_1004", "유저 기술스택 수정에 성공하였습니다."),
+    MEMBER_SIGN_UP_OK(HttpStatus.OK, "MEMBER_1005", "유저 회원가입에 성공하였습니다."),
+    MEMBER_LOGIN_OK(HttpStatus.OK, "MEMBER_1006", "유저 로그인에 성공하였습니다."),
+    MEMBER_LOGOUT_OK(HttpStatus.OK, "MEMBER_1007", "유저 로그아웃에 성공하였습니다."),
+    MEMBER_UPDATE_ACCESS_TOKEN_OK(HttpStatus.OK, "MEMBER_1008", "유저 액세스 토큰 재발급에 성공하였습니다."),
 
     // 레포지토리 관련 응답
     REPO_GET_TRENDING_OK(HttpStatus.OK, "REPO_2001", "트렌딩 레포지토리 리스트를 성공적으로 조회하였습니다."),

--- a/src/main/java/com/chungang/capstone/openstep/global/apiPayload/exception/handler/MemberHandler.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/apiPayload/exception/handler/MemberHandler.java
@@ -3,8 +3,8 @@ package com.chungang.capstone.openstep.global.apiPayload.exception.handler;
 import com.chungang.capstone.openstep.global.apiPayload.code.BaseErrorCode;
 import com.chungang.capstone.openstep.global.apiPayload.exception.GeneralException;
 
-public class MemberException extends GeneralException {
-    public MemberException(BaseErrorCode code) {
+public class MemberHandler extends GeneralException {
+    public MemberHandler(BaseErrorCode code) {
         super(code);
     }
 }

--- a/src/main/java/com/chungang/capstone/openstep/global/config/SecurityConfig.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/config/SecurityConfig.java
@@ -1,12 +1,14 @@
 package com.chungang.capstone.openstep.global.config;
 
 
+import com.chungang.capstone.openstep.global.security.filter.EmailPasswordAuthenticationFilter;
 import com.chungang.capstone.openstep.global.security.filter.JwtRequestFilter;
 import com.chungang.capstone.openstep.global.security.principal.PrincipalDetailsService;
 import com.chungang.capstone.openstep.global.security.provider.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -29,6 +31,8 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        AuthenticationManager authenticationManager = http.getSharedObject(AuthenticationManager.class);
+
         return http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .httpBasic(httpBasic -> httpBasic.disable())
@@ -38,6 +42,7 @@ public class SecurityConfig {
                         authorize -> authorize
                                 // Member 관련 접근
                                 .requestMatchers("/member/register", "/member/login/kakao", "/member/login/naver", "/member/login/email","/member/refresh").permitAll()
+                                .requestMatchers("/member/sign_up", "/member/login", "/member/logout", "/member/refresh").permitAll()
                                 .requestMatchers("/github/auth/**").permitAll()
 
                                 // Repo 관련 접근
@@ -53,7 +58,9 @@ public class SecurityConfig {
                                 .requestMatchers("/", "/api-docs/**", "/api-docs/swagger-config/*", "/swagger-ui/*", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                                 .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtRequestFilter(jwtTokenProvider, principalDetailsService), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new EmailPasswordAuthenticationFilter(authenticationManager), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtRequestFilter(jwtTokenProvider, principalDetailsService), EmailPasswordAuthenticationFilter.class)
+
 
                 .build();
     }

--- a/src/main/java/com/chungang/capstone/openstep/global/security/filter/EmailPasswordAuthenticationFilter.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/security/filter/EmailPasswordAuthenticationFilter.java
@@ -1,0 +1,26 @@
+package com.chungang.capstone.openstep.global.security.filter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+public class EmailPasswordAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    public EmailPasswordAuthenticationFilter(AuthenticationManager authenticationManager) {
+        super.setAuthenticationManager(authenticationManager);
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        String email = request.getParameter("email");
+        String password = request.getParameter("password");
+
+        UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(email, password);
+        setDetails(request, authRequest);
+        return this.getAuthenticationManager().authenticate(authRequest);
+    }
+}

--- a/src/main/java/com/chungang/capstone/openstep/global/security/principal/PrincipalDetails.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/security/principal/PrincipalDetails.java
@@ -27,12 +27,13 @@ public class PrincipalDetails implements UserDetails {
 
     @Override
     public String getPassword() {
-        return null;
+        return member.getPassword();
     }
 
     @Override
     public String getUsername() {
-        return member.getMemberId().toString();
+        //return member.getMemberId().toString();
+        return member.getEmail();
     }
 
     public String getGithubId() {

--- a/src/main/java/com/chungang/capstone/openstep/global/security/principal/PrincipalDetailsService.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/security/principal/PrincipalDetailsService.java
@@ -19,11 +19,19 @@ public class PrincipalDetailsService implements UserDetailsService {
 
     private final MemberRepository memberRepository;
 
-    @Override
-    public UserDetails loadUserByUsername(String memberId) throws UsernameNotFoundException {
-        Member member = memberRepository.findById(Long.parseLong(memberId))
-                .orElseThrow(() -> new AuthException(ErrorStatus.MEMBER_NOT_FOUND));
+//    @Override
+//    public UserDetails loadUserByUsername(String memberId) throws UsernameNotFoundException {
+//        Member member = memberRepository.findById(Long.parseLong(memberId))
+//                .orElseThrow(() -> new AuthException(ErrorStatus.MEMBER_NOT_FOUND));
+//
+//        return new PrincipalDetails(member);
+//    }
 
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new AuthException(ErrorStatus.MEMBER_NOT_FOUND));
         return new PrincipalDetails(member);
     }
+
 }

--- a/src/main/java/com/chungang/capstone/openstep/global/security/provider/JwtTokenProvider.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/security/provider/JwtTokenProvider.java
@@ -6,6 +6,8 @@ import io.jsonwebtoken.security.Keys;
 import com.chungang.capstone.openstep.global.apiPayload.exception.AuthException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.View;
 
@@ -13,11 +15,14 @@ import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.Date;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
 public class JwtTokenProvider {
 
+    private static final String AUTHORITIES_KEY = "auth";
+    private static final String BEARER_TYPE = "Bearer";
     private final SecretKey secretKey;
     private final Long accessTokenValidityMilliseconds;
     private final Long refreshTokenValidityMilliseconds;
@@ -78,5 +83,88 @@ public class JwtTokenProvider {
 
     private Jws<Claims> getClaims(String token) {
         return Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+    }
+
+    // token 생성
+    public TokenInfo generateToken(Authentication authentication) {
+        // 권한 가져오기
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+        // 현재 시간
+        long now = (new Date()).getTime();
+
+        // Access Token 생성
+        Date accessTokenExpiresIn = new Date(now + accessTokenValidityMilliseconds);
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim(AUTHORITIES_KEY, authorities)
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+
+        // Refresh Token 생성
+        String refreshToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .setExpiration(new Date(now + refreshTokenValidityMilliseconds))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+
+        return TokenInfo.builder()
+                .grantType(BEARER_TYPE)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .refreshTokenExpirationTime(new Date(now + refreshTokenValidityMilliseconds))
+                .build();
+    }
+
+    // 토큰 정보를 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT Token", e);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT Token", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT Token", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty.", e);
+        } catch (Exception e) {
+            System.out.println("잘못된 토큰 값입니다.");
+        }
+        return false;
+    }
+
+    public Date getExpirationTimeFromToken(String token) {
+        Claims claims = parseClaims(token);
+        return claims.getExpiration();
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(accessToken).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    public String getUserEmailFromToken(String token) {
+        Claims claims = parseClaims(token);
+        return claims.getSubject();
+    }
+
+    public String createAccessTokenByEmail(String email) {
+        long now = (new Date()).getTime();
+
+        String accessToken = Jwts.builder()
+                .setSubject(email)
+                .claim(AUTHORITIES_KEY, "ROLE_USER")
+                .setExpiration(new Date(now + accessTokenValidityMilliseconds))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+
+        return accessToken;
     }
 }

--- a/src/main/java/com/chungang/capstone/openstep/global/security/provider/TokenInfo.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/security/provider/TokenInfo.java
@@ -1,0 +1,17 @@
+package com.chungang.capstone.openstep.global.security.provider;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+
+import java.util.Date;
+
+@Builder
+@Data
+@Getter
+public class TokenInfo {
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+    private Date refreshTokenExpirationTime;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #60

## 📝작업 내용
> - 이메일 회원가입
> - 이메일 로그인 / 로그아웃
> - 액세스 토큰 재발급

## 🔎코드 설명 및 참고 사항
> - PasswordEncoder를 통한 비밀번호 암호화 및 AuthenticationManager 기반 인증 구현

## 💬리뷰 요구사항
>
