### PR TITLE
Refactor: PrincipalDetailsService에서 email 또는 memberId 모두 지원하도록 수정

### DIFF
--- a/src/main/java/com/chungang/capstone/openstep/global/security/principal/PrincipalDetailsService.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/security/principal/PrincipalDetailsService.java
@@ -19,13 +19,29 @@ public class PrincipalDetailsService implements UserDetailsService {
 
     private final MemberRepository memberRepository;
 
-   @Override
-   public UserDetails loadUserByUsername(String memberId) throws UsernameNotFoundException {
-       Member member = memberRepository.findById(Long.parseLong(memberId))
-               .orElseThrow(() -> new AuthException(ErrorStatus.MEMBER_NOT_FOUND));
+    @Override
+    public UserDetails loadUserByUsername(String identifier) throws UsernameNotFoundException {
+        try {
+            // 숫자면 memberId로 간주 (토큰 인증시)
+            Long memberId = Long.parseLong(identifier);
+            Member member = memberRepository.findById(memberId)
+                    .orElseThrow(() -> new AuthException(ErrorStatus.MEMBER_NOT_FOUND));
+            return new PrincipalDetails(member);
+        } catch (NumberFormatException e) {
+            // 그 외는 email로 간주 (이메일 로그인시)
+            Member member = memberRepository.findByEmail(identifier)
+                    .orElseThrow(() -> new AuthException(ErrorStatus.MEMBER_NOT_FOUND));
+            return new PrincipalDetails(member);
+        }
+    }
 
-       return new PrincipalDetails(member);
-   }
+    //   @Override
+    //   public UserDetails loadUserByUsername(String memberId) throws UsernameNotFoundException {
+    //       Member member = memberRepository.findById(Long.parseLong(memberId))
+    //               .orElseThrow(() -> new AuthException(ErrorStatus.MEMBER_NOT_FOUND));
+    //
+    //       return new PrincipalDetails(member);
+    //   }
 
     // @Override
     // public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {


### PR DESCRIPTION
## #️⃣연관된 이슈
> #32
## 📝작업 내용
> PrincipalDetailsService에서 email 또는 memberId 모두 지원하도록 수정

## 🔎코드 설명 및 참고 사항
> 로그인은 email로, JWT 인증은 memberId로 인증 가능하도록 PrincipalDetailsService 개선

## 💬리뷰 요구사항
>
