### PR TITLE
Feat: 사용자 맞춤 이슈 추천 API 구현

### DIFF
--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -1,32 +1,32 @@
+#version: '3'
+#
 #services:
 #  app:
 #    build: .
 #    image: harryest/openstep:dev
 #    ports:
-#      - "8080:8080"
+#      - "8081:8080"
 #    environment:
 #      SPRING_DATASOURCE_URL: jdbc:mysql://openstep.cpgoe06g6rjt.ap-northeast-2.rds.amazonaws.com:3306/openstep_db
 #      SPRING_DATASOURCE_USERNAME: root
 #      SPRING_DATASOURCE_PASSWORD: Capstoneteam01!
 #    depends_on:
-#      - mysql-db
+#      - redis
 #    networks:
 #      - openstep-network
 #
-#  mysql-db:
-#    image: mysql:8.0
-#    environment:
-#      MYSQL_ROOT_PASSWORD: root
-#      MYSQL_DATABASE: openstep_db
+#  redis:
+#    image: redis:7.0
+#    container_name: openstep-redis
 #    ports:
-#      - "3306:3306"
-#    volumes:
-#      - mysql-data:/var/lib/mysql
+#      - "6379:6379"
 #    networks:
 #      - openstep-network
+#    volumes:
+#      - redis_data:/data
 #
 #networks:
 #  openstep-network:
 #
 #volumes:
-#  mysql-data:
+#  redis_data:

--- a/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/GitHubIssueResponse.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/GitHubIssueResponse.java
@@ -1,6 +1,7 @@
 package com.chungang.capstone.openstep.domain.Github.dto;
 
 import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
 
@@ -11,17 +12,31 @@ public class GitHubIssueResponse {
     @Getter
     public static class Data {
         private Repository repository;
+        private Search search;
+    }
+
+    @Getter
+    public static class Search {
+        private List<Edge> edges;
+    }
+
+    @Getter
+    public static class Edge {
+        private GitHubIssueResponse.IssueNode node;
     }
 
     @Getter
     public static class Repository {
         private String name;
         private Issues issues;
+        private Owner owner;
     }
 
     @Getter
+    @Setter
     public static class Issues {
         private List<IssueNode> nodes;
+        private int totalCount;
     }
 
     @Getter
@@ -29,10 +44,21 @@ public class GitHubIssueResponse {
         private String title;
         private String body;
         private String url;
-        private String createdAt;
-        private String updatedAt;
+        private String repo;
         private Author author;
         private Labels labels;
+        private String state;
+        private Language primaryLanguage;
+        private Issues goodFirstIssue;
+        private int stargazerCount;
+        private String createdAt;
+        private String updatedAt;
+        private Repository repository;
+
+        public int getGoodFirstIssueCount() {
+            return goodFirstIssue != null ? goodFirstIssue.getTotalCount() : 0;
+        }
+
     }
 
     @Getter
@@ -50,5 +76,14 @@ public class GitHubIssueResponse {
         private String name;
     }
 
+    @Getter
+    public static class Language {
+        private String name;
+    }
+
+    @Getter
+    public static class Owner {
+        private String login;
+    }
 
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/GitHubRepoResponse.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/GitHubRepoResponse.java
@@ -35,7 +35,7 @@ public class GitHubRepoResponse {
         private Integer forkCount;
         private Issues openIssues;
         private Issues closedIssues;
-        private Issues goodFirstIssue;
+        private Issues beginnerIssues;
         public Watchers watchers;
         private String updatedAt;
 
@@ -54,8 +54,8 @@ public class GitHubRepoResponse {
             return closedIssues != null ? closedIssues.getTotalCount() : 0;
         }
 
-        public int getGoodFirstIssueCount() {
-            return goodFirstIssue != null ? goodFirstIssue.getTotalCount() : 0;
+        public int getBeginnerIssueCount() {
+            return beginnerIssues != null ? beginnerIssues.getTotalCount() : 0;
         }
     }
 

--- a/src/main/java/com/chungang/capstone/openstep/domain/Github/service/GitHubGraphQLService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Github/service/GitHubGraphQLService.java
@@ -188,6 +188,7 @@ public class GitHubGraphQLService {
         }
     }
 
+    // 레포지토리 사용자 맞춤 추천을 위한 검색
     public GitHubRepoResponse searchRepositories(String query) {
         String finalQuery = String.format("""
         {
@@ -204,7 +205,10 @@ public class GitHubGraphQLService {
                   forkCount
                   openIssues: issues(states: OPEN) { totalCount }
                   closedIssues: issues(states: CLOSED) { totalCount }
-                  goodFirstIssue: issues(labels: ["good first issue"]) { totalCount }
+                  beginnerIssues: issues(labels: ["good first issue", "help wanted", "beginner friendly"]) {
+                            totalCount
+                          }
+                
                   watchers { totalCount }
                   updatedAt
                 }
@@ -230,5 +234,6 @@ public class GitHubGraphQLService {
             throw new GithubGraphQLException(ErrorStatus.GITHUB_GRAPHQL_ERROR);
         }
     }
+
 
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Github/util/GitHubQueryBuilder.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Github/util/GitHubQueryBuilder.java
@@ -77,9 +77,11 @@ public class GitHubQueryBuilder {
         allKeywords.addAll(domains);
 
         String query = String.join(" ", allKeywords).toLowerCase() + " sort:stars-desc";
-        log.info("🔍 Broad keywords: {}", allKeywords);
-        log.info("🔍 Fallback natural query: {}", query);
+        log.info("Broad keywords: {}", allKeywords);
+        log.info("Fallback natural query: {}", query);
         return query;
     }
+
+
 
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/controller/IssueController.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/controller/IssueController.java
@@ -35,8 +35,8 @@ public class IssueController {
 	// 트렌딩 이슈 목록 조회 API
 	@GetMapping("/trending")
 	@Operation(summary = "트렌딩 issue 조회 API", description = "현재 인기 있는 트렌딩한 오픈소스 이슈를 조회합니다.")
-	public ApiResponse<List<IssueResponseDTO.TrendingIssueDTO>> getTrendingIssues() {
-		List<IssueResponseDTO.TrendingIssueDTO> issues = issueQueryService.getTrendingIssues();
+	public ApiResponse<List<IssueResponseDTO.IssueSimpleDTO>> getTrendingIssues() {
+		List<IssueResponseDTO.IssueSimpleDTO> issues = issueQueryService.getTrendingIssues();
 		return ApiResponse.onSuccess(SuccessStatus.ISSUE_GET_TRENDING_OK, issues);
 	}
 
@@ -56,6 +56,15 @@ public class IssueController {
 		Member member = SecurityUtils.getCurrentMember();
 		Task task = issueCommandService.makeTask(member, issueId);
 		return ApiResponse.onSuccess(SuccessStatus.TASK_ASSIGN_OK, IssueConverter.toIssueAssignDTO(task));
+	}
+
+	// 사용자 맞춤 이슈 추천
+	@GetMapping("/suggest")
+	@Operation(summary = "사용자 맞춤 이슈 추천 API", description = "사용자의 관심사에 맞는 오픈소스 이슈를 추천합니다.")
+	public ApiResponse<IssueResponseDTO.IssueListDTO> suggestIssues() {
+		Member member = SecurityUtils.getCurrentMember();
+		List<Issue> issues = issueQueryService.getSuggestedIssues(member);
+		return ApiResponse.onSuccess(SuccessStatus.ISSUE_GET_SUGGEST_OK, IssueConverter.toIssueListDTO(issues));
 	}
 
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/converter/IssueConverter.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/converter/IssueConverter.java
@@ -24,7 +24,7 @@ public class IssueConverter {
     public static List<IssueResponseDTO.IssueSimpleDTO> toIssueSimpleDTOs(List<Issue> issues) {
         return issues.stream()
                 .map(issue -> {
-                    String filteredBody = (issue.getBody() == null || issue.getBody().length() < 200 || !issue.getBody().matches(".*[가-힣a-zA-Z].*"))
+                    String filteredBody = (issue.getBody() == null || issue.getBody().length() < 500 || !issue.getBody().matches(".*[가-힣a-zA-Z].*"))
                             ? "내용 없음"
                             : issue.getBody();
 
@@ -33,6 +33,7 @@ public class IssueConverter {
                             .title(issue.getTitle())
                             .body(filteredBody)
                             .summary(issue.getSummary())
+                            .language(issue.getLanguage())
                             .url(issue.getGithubUrl())
                             .createdAt(issue.getCreatedAt() != null ? issue.getCreatedAt().toString() : null)
                             .updatedAt(issue.getUpdatedAt() != null ? issue.getUpdatedAt().toString() : null)
@@ -50,12 +51,19 @@ public class IssueConverter {
                 .title(issue.getTitle())
                 .body(issue.getBody())
                 .summary(issue.getSummary())
+                .language(issue.getLanguage())
                 .author(issue.getAuthor())
                 .createdAt(issue.getCreatedAt() != null ? issue.getCreatedAt().toString() : null)
                 .updatedAt(issue.getUpdatedAt() != null ? issue.getUpdatedAt().toString() : null)
                 .labels(issue.getLabels())
                 .url(issue.getGithubUrl())
                 .build();
+    }
+
+    public static List<IssueResponseDTO.IssueDetailDTO> toIssueDetailDTOs(List<Issue> issues) {
+        return issues.stream()
+                .map(IssueConverter::toIssueDetailDTO)
+                .collect(Collectors.toList());
     }
 
     public static IssueResponseDTO.IssueListDTO toIssueListDTO(List<Issue> issues) {

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/converter/IssueConverter.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/converter/IssueConverter.java
@@ -21,14 +21,14 @@ public class IssueConverter {
 //                        .build())
 //                .collect(Collectors.toList());
 //    }
-    public static List<IssueResponseDTO.TrendingIssueDTO> toTrendingDTOs(List<Issue> issues) {
+    public static List<IssueResponseDTO.IssueSimpleDTO> toIssueSimpleDTOs(List<Issue> issues) {
         return issues.stream()
                 .map(issue -> {
                     String filteredBody = (issue.getBody() == null || issue.getBody().length() < 200 || !issue.getBody().matches(".*[가-힣a-zA-Z].*"))
                             ? "내용 없음"
                             : issue.getBody();
 
-                    return IssueResponseDTO.TrendingIssueDTO.builder()
+                    return IssueResponseDTO.IssueSimpleDTO.builder()
                             .issueId(issue.getIssueId())
                             .title(issue.getTitle())
                             .body(filteredBody)
@@ -51,10 +51,16 @@ public class IssueConverter {
                 .body(issue.getBody())
                 .summary(issue.getSummary())
                 .author(issue.getAuthor())
-                .createdAt(issue.getCreatedAt().toString())
-                .updatedAt(issue.getUpdatedAt().toString())
+                .createdAt(issue.getCreatedAt() != null ? issue.getCreatedAt().toString() : null)
+                .updatedAt(issue.getUpdatedAt() != null ? issue.getUpdatedAt().toString() : null)
                 .labels(issue.getLabels())
                 .url(issue.getGithubUrl())
+                .build();
+    }
+
+    public static IssueResponseDTO.IssueListDTO toIssueListDTO(List<Issue> issues) {
+        return IssueResponseDTO.IssueListDTO.builder()
+                .issueList(toIssueSimpleDTOs(issues))
                 .build();
     }
 

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/dto/IssueResponseDTO.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/dto/IssueResponseDTO.java
@@ -17,6 +17,7 @@ public class IssueResponseDTO {
         private String title;
         private String body;
         private String summary;
+        private String language;
         private String url;
         private String createdAt;
         private String updatedAt;
@@ -34,6 +35,7 @@ public class IssueResponseDTO {
         private String title;
         private String body;
         private String summary;
+        private String language;
         private String url;
         private String createdAt;
         private String updatedAt;

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/dto/IssueResponseDTO.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/dto/IssueResponseDTO.java
@@ -12,7 +12,7 @@ public class IssueResponseDTO {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class TrendingIssueDTO {
+    public static class IssueSimpleDTO {
         private Long issueId;
         private String title;
         private String body;
@@ -52,4 +52,11 @@ public class IssueResponseDTO {
         String updatedAt
     ) { }
 
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class IssueListDTO {
+        private List<IssueSimpleDTO> issueList;
+    }
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/entity/Issue.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/entity/Issue.java
@@ -3,12 +3,14 @@ package com.chungang.capstone.openstep.domain.Issue.entity;
 import com.chungang.capstone.openstep.domain.Repo.entity.Repo;
 import com.chungang.capstone.openstep.domain.Task.entity.Task;
 import com.chungang.capstone.openstep.domain.common.BaseEntity;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -25,6 +27,7 @@ public class Issue extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "repo_id", nullable = false)
+    @JsonBackReference
     private Repo repo;
 
     @Column(columnDefinition = "varchar(500)", length = 500)
@@ -36,12 +39,14 @@ public class Issue extends BaseEntity {
     @Column(unique = true)
     private String githubUrl;
 
-    private String status; // OPEN, CLOSED 등
+    private String state; // OPEN, CLOSED 등
 
     private String author;
 
     @Column(columnDefinition = "TEXT")
     private String summary;
+
+    private String language;
 
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "issue_labels", joinColumns = @JoinColumn(name = "issue_id"))
@@ -50,10 +55,27 @@ public class Issue extends BaseEntity {
 
     private LocalDateTime createdAt;
 
+
     private LocalDateTime updatedAt;
+
+    private int stars;
 
     @OneToMany(mappedBy = "issue", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Task> tasks = new ArrayList<>();
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Issue)) return false;
+        Issue issue = (Issue) o;
+        return Objects.equals(githubUrl, issue.githubUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(githubUrl);
+    }
 }
 
 

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/repository/IssueRepository.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/repository/IssueRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface IssueRepository extends JpaRepository<Issue, Long> {
     Optional<Issue> findByGithubUrl(String githubUrl);
+
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueCacheService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueCacheService.java
@@ -1,0 +1,124 @@
+package com.chungang.capstone.openstep.domain.Issue.service;
+
+import com.chungang.capstone.openstep.domain.Issue.entity.Issue;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class IssueCacheService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private final long CACHE_EXPIRE_SECONDS = 60L * 60 * 24 * 60; // TTL 60일
+
+    // 사용자별 추천 캐시 (기존 유지)
+    public void saveRecommendedIssues(Long memberId, List<Issue> issues) {
+        String key = generateMemberKey(memberId);
+        try {
+            String json = objectMapper.writeValueAsString(issues);
+            redisTemplate.opsForValue().set(key, json, CACHE_EXPIRE_SECONDS, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException("Redis 저장 중 오류 발생", e);
+        }
+    }
+
+    public List<Issue> getRecommendedIssues(Long memberId) {
+        String key = generateMemberKey(memberId);
+        String cached = redisTemplate.opsForValue().get(key);
+        if (cached == null) return null;
+
+        try {
+            return objectMapper.readValue(cached, new TypeReference<List<Issue>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("Redis 조회 중 역직렬화 실패", e);
+        }
+    }
+
+    // 새로운 관심 언어 + 관심 도메인 조합 캐시
+    public void saveIssuesByLanguageAndDomain(String lang, String domain, List<Issue> issues) {
+        String key = generateInterestKey(lang, domain);
+        try {
+            String json = objectMapper.writeValueAsString(issues);
+            redisTemplate.opsForValue().set(key, json, CACHE_EXPIRE_SECONDS, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException("관심조합 Redis 저장 중 오류 발생", e);
+        }
+    }
+
+    public List<Issue> getIssuesByLanguageAndDomain(String lang, String domain) {
+        String key = generateInterestKey(lang, domain);
+        String cached = redisTemplate.opsForValue().get(key);
+        if (cached == null) return null;
+
+        try {
+            return objectMapper.readValue(cached, new TypeReference<List<Issue>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("관심조합 Redis 역직렬화 실패", e);
+        }
+    }
+
+    public void evict(Long memberId) {
+        redisTemplate.delete(generateMemberKey(memberId));
+    }
+
+    private String generateMemberKey(Long memberId) {
+        return "recommend:issues:user:" + memberId;
+    }
+
+    private String generateInterestKey(String lang, String domain) {
+        return "recommend:issues:interest:" + lang.toLowerCase() + ":" + domain.toLowerCase();
+    }
+
+    public void saveIssuesByLanguage(String lang, List<Issue> issues) {
+        String key = "recommend:issues:lang:" + lang.toLowerCase();
+        try {
+            String json = objectMapper.writeValueAsString(issues);
+            redisTemplate.opsForValue().set(key, json, CACHE_EXPIRE_SECONDS, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException("언어 기반 Redis 저장 중 오류 발생", e);
+        }
+    }
+
+    public void saveIssuesByDomain(String domain, List<Issue> issues) {
+        String key = "recommend:issues:domain:" + domain.toLowerCase();
+        try {
+            String json = objectMapper.writeValueAsString(issues);
+            redisTemplate.opsForValue().set(key, json, CACHE_EXPIRE_SECONDS, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException("도메인 기반 Redis 저장 중 오류 발생", e);
+        }
+    }
+
+    public List<Issue> getIssuesByLanguage(String lang) {
+        String key = "recommend:issues:lang:" + lang.toLowerCase();
+        String cached = redisTemplate.opsForValue().get(key);
+        if (cached == null) return null;
+
+        try {
+            return objectMapper.readValue(cached, new TypeReference<List<Issue>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("언어 기반 Redis 역직렬화 실패", e);
+        }
+    }
+
+    public List<Issue> getIssuesByDomain(String domain) {
+        String key = "recommend:issues:domain:" + domain.toLowerCase();
+        String cached = redisTemplate.opsForValue().get(key);
+        if (cached == null) return null;
+
+        try {
+            return objectMapper.readValue(cached, new TypeReference<List<Issue>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("도메인 기반 Redis 역직렬화 실패", e);
+        }
+    }
+
+}

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueQueryService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueQueryService.java
@@ -6,6 +6,7 @@ import com.chungang.capstone.openstep.domain.Issue.repository.IssueRepository;
 import com.chungang.capstone.openstep.domain.Issue.dto.IssueResponseDTO;
 import com.chungang.capstone.openstep.domain.Github.service.GitHubGraphQLService;
 import com.chungang.capstone.openstep.domain.Issue.converter.IssueConverter;
+import com.chungang.capstone.openstep.domain.Member.entity.Member;
 import com.chungang.capstone.openstep.domain.OpenAI.service.OpenAIService;
 import com.chungang.capstone.openstep.domain.Repo.entity.Repo;
 import com.chungang.capstone.openstep.domain.Repo.repository.RepoRepository;
@@ -30,7 +31,7 @@ public class IssueQueryService {
     private final RepoRepository repoRepository;
     private final OpenAIService openAIService;
 
-    public List<IssueResponseDTO.TrendingIssueDTO> getTrendingIssues() {
+    public List<IssueResponseDTO.IssueSimpleDTO> getTrendingIssues() {
         List<Repo> repos = repoRepository.findAll(); // DB에 있는 5개 레포 사용
         List<Issue> allIssues = new ArrayList<>();
 
@@ -49,11 +50,11 @@ public class IssueQueryService {
                         .toList();
 
                 allIssues.addAll(savedIssues);
-                System.out.println("📌 " + owner + "/" + repoName + " 의 이슈 수: " + issueNodes.size());
+                System.out.println("[*] " + owner + "/" + repoName + " 의 이슈 수: " + issueNodes.size());
             }
         }
 
-        return IssueConverter.toTrendingDTOs(allIssues);
+        return IssueConverter.toIssueSimpleDTOs(allIssues);
     }
 
     private Issue saveIfNotExists(GitHubIssueResponse.IssueNode node, Repo repo) {
@@ -122,5 +123,11 @@ public class IssueQueryService {
         return issueRepository.findById(issueId)
                 .orElseThrow(() -> new IssueHandler(ErrorStatus.ISSUE_NOT_FOUND));
     }
+
+    // 사용자 맞춤 이슈 추천
+    public List<Issue> getSuggestedIssues(Member member) {
+        return null;
+    }
+
 
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueQueryService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueQueryService.java
@@ -1,133 +1,231 @@
 package com.chungang.capstone.openstep.domain.Issue.service;
 
 import com.chungang.capstone.openstep.domain.Github.dto.GitHubIssueResponse;
+import com.chungang.capstone.openstep.domain.Github.service.GitHubGraphQLService;
+import com.chungang.capstone.openstep.domain.Github.util.GitHubQueryBuilder;
+import com.chungang.capstone.openstep.domain.Issue.converter.IssueConverter;
+import com.chungang.capstone.openstep.domain.Issue.dto.IssueResponseDTO;
 import com.chungang.capstone.openstep.domain.Issue.entity.Issue;
 import com.chungang.capstone.openstep.domain.Issue.repository.IssueRepository;
-import com.chungang.capstone.openstep.domain.Issue.dto.IssueResponseDTO;
-import com.chungang.capstone.openstep.domain.Github.service.GitHubGraphQLService;
-import com.chungang.capstone.openstep.domain.Issue.converter.IssueConverter;
 import com.chungang.capstone.openstep.domain.Member.entity.Member;
+import com.chungang.capstone.openstep.domain.Member.repository.MemberDomainRepository;
+import com.chungang.capstone.openstep.domain.Member.repository.MemberLanguageRepository;
 import com.chungang.capstone.openstep.domain.OpenAI.service.OpenAIService;
 import com.chungang.capstone.openstep.domain.Repo.entity.Repo;
 import com.chungang.capstone.openstep.domain.Repo.repository.RepoRepository;
+import com.chungang.capstone.openstep.domain.Repo.service.RepoQueryService;
+import com.chungang.capstone.openstep.domain.common.InterestDomain;
+import com.chungang.capstone.openstep.domain.common.InterestLanguage;
 import com.chungang.capstone.openstep.global.apiPayload.code.status.ErrorStatus;
 import com.chungang.capstone.openstep.global.apiPayload.exception.handler.IssueHandler;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.time.ZoneId;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class IssueQueryService {
-
-    private final IssueRepository issueRepository;
-
-    private final GitHubGraphQLService gitHubGraphQLService;
     private final RepoRepository repoRepository;
+    private final IssueRepository issueRepository;
+    private final RepoQueryService repoQueryService;
+    private final GitHubGraphQLService gitHubGraphQLService;
+    private final IssueCacheService issueCacheService;
     private final OpenAIService openAIService;
+    private final MemberLanguageRepository memberLanguageRepository;
+    private final MemberDomainRepository memberDomainRepository;
 
     public List<IssueResponseDTO.IssueSimpleDTO> getTrendingIssues() {
-        List<Repo> repos = repoRepository.findAll(); // DB에 있는 5개 레포 사용
+        List<Repo> repos = repoRepository.findAll();
         List<Issue> allIssues = new ArrayList<>();
-
         for (Repo repo : repos) {
-            String owner = repo.getOwnerName();
-            String repoName = repo.getRepoName();
-
-            GitHubIssueResponse issueResponse = gitHubGraphQLService.fetchIssuesByRepo(owner, repoName);
-
-            if (issueResponse != null && issueResponse.getData().getRepository() != null) {
-                var issueNodes = issueResponse.getData().getRepository().getIssues().getNodes();
-
-                List<Issue> savedIssues = issueNodes.stream()
-                        .map(node -> saveIfNotExists(node, repo))
+            GitHubIssueResponse res = gitHubGraphQLService.fetchIssuesByRepo(repo.getOwnerName(), repo.getRepoName());
+            if (res != null && res.getData().getRepository() != null) {
+                List<Issue> issues = res.getData().getRepository().getIssues().getNodes().stream()
+                        .map(node -> saveIfNotExistsOrUpdate(node, repo))
                         .filter(Objects::nonNull)
                         .toList();
-
-                allIssues.addAll(savedIssues);
-                System.out.println("[*] " + owner + "/" + repoName + " 의 이슈 수: " + issueNodes.size());
+                allIssues.addAll(issues);
             }
         }
-
         return IssueConverter.toIssueSimpleDTOs(allIssues);
     }
 
-    private Issue saveIfNotExists(GitHubIssueResponse.IssueNode node, Repo repo) {
-        if (node.getTitle() == null || node.getTitle().length() < 1) return null;
+    public List<Issue> getSuggestedIssues(Member member) {
+        Long memberId = member.getMemberId();
+        log.info("[ISSUE_RECOMMEND] Start for memberId = {}", memberId);
 
-//        String rawBody = node.getBody();
-//        String body = (rawBody == null || rawBody.length() < 20 || !rawBody.matches(".*[가-힣a-zA-Z].*"))
-//                ? "내용 없음"
-//                : rawBody;
+        issueCacheService.evict(memberId);
+        List<Issue> cached = issueCacheService.getRecommendedIssues(memberId);
+        if (cached != null) {
+            log.info("[ISSUE_RECOMMEND] Cache hit: {} issues", cached.size());
+            return cached;
+        }
 
-        String body = node.getBody();
+        List<Repo> suggestedRepos = repoQueryService.getSuggestedRepos(memberId);
+        log.info("[ISSUE_RECOMMEND] Suggested repos count = {}", suggestedRepos.size());
 
-        List<String> labels = node.getLabels() != null
-                ? node.getLabels().getNodes().stream().map(GitHubIssueResponse.LabelNode::getName).toList()
-                : Collections.emptyList();
+        List<Issue> collectedIssues = new ArrayList<>();
+        List<Issue> fallbackIssues = new ArrayList<>();
+        OffsetDateTime threeMonthsAgo = OffsetDateTime.now().minusMonths(3);
 
-        boolean isGoodLabel = labels.stream().anyMatch(label ->
-                label.toLowerCase().contains("good first issue") || label.toLowerCase().contains("help wanted"));
+        for (Repo repo : suggestedRepos) {
+            String owner = repo.getOwnerName();
+            String name = repo.getRepoName();
+            log.info("[ISSUE_RECOMMEND] Fetching issues from repo: {}/{}", owner, name);
 
-        if (!isGoodLabel) return null;
+            GitHubIssueResponse response = gitHubGraphQLService.fetchIssuesByRepo(owner, name);
+            if (response == null || response.getData() == null || response.getData().getRepository() == null) {
+                log.warn("[ISSUE_RECOMMEND] Null or incomplete response from repo: {}/{}", owner, name);
+                continue;
+            }
 
-        return issueRepository.findByGithubUrl(node.getUrl())
-                .orElseGet(() -> issueRepository.save(toIssueEntity(node, repo, body)));
+            List<GitHubIssueResponse.IssueNode> nodes = response.getData().getRepository().getIssues().getNodes();
+
+            for (GitHubIssueResponse.IssueNode node : nodes) {
+                OffsetDateTime updatedAt = OffsetDateTime.parse(node.getUpdatedAt());
+                if (updatedAt.isBefore(threeMonthsAgo)) continue;
+
+                // 🧠 중복 방지: githubUrl 기준 확인
+                if (issueRepository.findByGithubUrl(node.getUrl()).isPresent()) continue;
+
+                Issue issue = Issue.builder()
+                        .repo(repo)
+                        .title(node.getTitle())
+                        .body(Optional.ofNullable(node.getBody()).orElse("내용 없음"))
+                        .summary(null)
+                        .githubUrl(node.getUrl())
+                        .author(node.getAuthor() != null ? node.getAuthor().getLogin() : "Unknown")
+                        .createdAt(OffsetDateTime.parse(node.getCreatedAt()).atZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime())
+                        .updatedAt(updatedAt.atZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime())
+                        .language(repo.getLanguage())
+                        .labels(node.getLabels().getNodes().stream().map(GitHubIssueResponse.LabelNode::getName).toList())
+                        .state("OPEN")
+                        .build();
+
+                boolean isBeginnerLabel = issue.getLabels().stream()
+                        .map(String::toLowerCase)
+                        .anyMatch(label ->
+                                label.contains("good") ||
+                                        label.contains("help") ||
+                                        label.contains("beginner") ||
+                                        label.contains("starter") ||
+                                        label.contains("easy")
+                        );
+
+                if (isBeginnerLabel) {
+                    collectedIssues.add(issue);
+                } else {
+                    fallbackIssues.add(issue);
+                }
+
+                if (collectedIssues.size() >= 50) break;
+            }
+
+            if (collectedIssues.size() >= 50) break;
+        }
+
+        int need = 20;
+        List<Issue> top20 = collectedIssues.stream()
+                .sorted(Comparator.comparing(Issue::getUpdatedAt).reversed())
+                .limit(need)
+                .collect(Collectors.toList());
+
+        if (top20.size() < need) {
+            int remaining = need - top20.size();
+            List<Issue> fallback = fallbackIssues.stream()
+                    .sorted(Comparator.comparing(Issue::getUpdatedAt).reversed())
+                    .limit(remaining)
+                    .toList();
+            top20.addAll(fallback);
+        }
+
+        // 🔥 요약 + 저장 (중복 방지 포함)
+        List<Issue> summarized = top20.stream()
+                .map(issue -> {
+                    String summary;
+                    try {
+                        String raw = openAIService.summarizeIssue(issue.getTitle(), issue.getBody());
+                        summary = openAIService.rewriteNaturalKorean(raw);
+                    } catch (Exception e) {
+                        log.warn("[SUMMARY] OpenAI 요약 실패: {}", issue.getGithubUrl(), e);
+                        summary = "요약을 생성할 수 없습니다.";
+                    }
+
+                    issue.setSummary(summary);
+
+                    // 중복 저장 방지
+                    return issueRepository.findByGithubUrl(issue.getGithubUrl())
+                            .orElseGet(() -> issueRepository.save(issue));
+                })
+                .toList();
+
+        issueCacheService.saveRecommendedIssues(memberId, summarized);
+        log.info("[ISSUE_RECOMMEND] Final recommended issues count = {}", summarized.size());
+        return summarized;
     }
 
-//    private Issue saveIfNotExists(GitHubIssueResponse.IssueNode node, Repo repo) {
-//        if (node.getTitle() == null || node.getTitle().length() < 1) return null;
-//
-//        String rawBody = node.getBody(); // 그대로 저장
-//        List<String> labels = node.getLabels() != null
-//                ? node.getLabels().getNodes().stream().map(GitHubIssueResponse.LabelNode::getName).toList()
-//                : Collections.emptyList();
-//
-//        boolean isGoodLabel = labels.stream().anyMatch(label ->
-//                label.toLowerCase().contains("good first issue") || label.toLowerCase().contains("help wanted"));
-//
-//        if (!isGoodLabel) return null;
-//
-//        return issueRepository.findByGithubUrl(node.getUrl())
-//                .orElseGet(() -> issueRepository.save(toIssueEntity(node, repo, rawBody)));
-//    }
 
+    private Issue saveIfNotExistsOrUpdate(GitHubIssueResponse.IssueNode node, Repo repo) {
+        Optional<Issue> existing = issueRepository.findByGithubUrl(node.getUrl());
+        String body = Optional.ofNullable(node.getBody()).orElse("내용 없음");
+
+        if (existing.isPresent()) {
+            Issue issue = existing.get();
+            issue.setTitle(node.getTitle());
+            issue.setBody(body);
+            issue.setUpdatedAt(OffsetDateTime.parse(node.getUpdatedAt()).toLocalDateTime());
+            issue.setSummary(updateSummary(issue));
+            return issueRepository.save(issue);
+        } else {
+            Issue issue = toIssueEntity(node, repo, body);
+            return issueRepository.save(issue);
+        }
+    }
 
     private Issue toIssueEntity(GitHubIssueResponse.IssueNode node, Repo repo, String body) {
-        String summary = openAIService.summarizeIssue(node.getTitle(), body);
-        String refinedSummary = openAIService.rewriteNaturalKorean(summary);
+        String summary = updateSummary(Issue.builder()
+                .title(node.getTitle())
+                .body(body)
+                .build());
 
         return Issue.builder()
                 .repo(repo)
                 .title(node.getTitle())
                 .body(body)
-                .summary(refinedSummary)
+                .summary(summary)
                 .githubUrl(node.getUrl())
                 .author(node.getAuthor() != null ? node.getAuthor().getLogin() : "unknown")
-                .labels(node.getLabels() != null
-                        ? node.getLabels().getNodes().stream().map(GitHubIssueResponse.LabelNode::getName).toList()
-                        : Collections.emptyList())
-                .createdAt(node.getCreatedAt() != null ? OffsetDateTime.parse(node.getCreatedAt()).toLocalDateTime() : null)
-                .updatedAt(node.getUpdatedAt() != null ? OffsetDateTime.parse(node.getUpdatedAt()).toLocalDateTime() : null)
-                .status("OPEN")
+                .labels(new ArrayList<>(
+                        node.getLabels() != null
+                                ? node.getLabels().getNodes().stream().map(GitHubIssueResponse.LabelNode::getName).toList()
+                                : Collections.emptyList()
+                ))
+                .createdAt(OffsetDateTime.parse(node.getCreatedAt()).toLocalDateTime())
+                .updatedAt(OffsetDateTime.parse(node.getUpdatedAt()).toLocalDateTime())
+                .state("OPEN")
+                .language(repo.getLanguage())
                 .build();
     }
 
+    private String updateSummary(Issue issue) {
+        try {
+            String raw = openAIService.summarizeIssue(issue.getTitle(), issue.getBody());
+            return openAIService.rewriteNaturalKorean(raw);
+        } catch (Exception e) {
+            log.warn("[SUMMARY] 요약 실패: {}", issue.getGithubUrl(), e);
+            return "요약을 생성할 수 없습니다.";
+        }
+    }
+
+
 
     public Issue getIssueById(Long issueId) {
-        return issueRepository.findById(issueId)
-                .orElseThrow(() -> new IssueHandler(ErrorStatus.ISSUE_NOT_FOUND));
+        return issueRepository.findById(issueId).orElseThrow(() -> new IssueHandler(ErrorStatus.ISSUE_NOT_FOUND));
     }
-
-    // 사용자 맞춤 이슈 추천
-    public List<Issue> getSuggestedIssues(Member member) {
-        return null;
-    }
-
-
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/converter/RepoConverter.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/converter/RepoConverter.java
@@ -20,6 +20,7 @@ public class RepoConverter {
                         .forks(repo.getForks())
                         .openIssues(repo.getOpenIssues())
                         .closedIssues(repo.getClosedIssues())
+                        .beginnerIssueCount(repo.getBeginnerIssueCount())
                         .githubUrl(repo.getGithubUrl())
                         .description(repo.getDescription())
                         .build())
@@ -40,6 +41,7 @@ public class RepoConverter {
                 .forks(repo.getForks())
                 .openIssues(repo.getOpenIssues())
                 .closedIssues(repo.getClosedIssues())
+                .beginnerIssueCount(repo.getBeginnerIssueCount())
                 .githubUrl(repo.getGithubUrl())
                 .readmeUrl(repo.getReadmeUrl())
                 .build();

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/dto/RepoResponseDTO.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/dto/RepoResponseDTO.java
@@ -24,6 +24,7 @@ public class RepoResponseDTO {
         private Integer forks;
         private Integer openIssues;
         private Integer closedIssues;
+        private Integer beginnerIssueCount;
         private String githubUrl;
         private String description;
     }
@@ -44,6 +45,7 @@ public class RepoResponseDTO {
         private int forks;
         private int openIssues;
         private int closedIssues;
+        private Integer beginnerIssueCount;
         private String githubUrl;
         private String readmeUrl;
     }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/entity/Repo.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/entity/Repo.java
@@ -3,6 +3,7 @@ package com.chungang.capstone.openstep.domain.Repo.entity;
 import com.chungang.capstone.openstep.domain.Bookmark.entity.Bookmark;
 import com.chungang.capstone.openstep.domain.Issue.entity.Issue;
 import com.chungang.capstone.openstep.domain.common.BaseEntity;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -39,8 +40,8 @@ public class Repo extends BaseEntity {
     private int openIssues;
     private int closedIssues;
 
-    @Column(name = "good_first_issue_count")
-    private int goodFirstIssueCount;
+    @Column(name = "beginner_issue_count")
+    private int beginnerIssueCount;
 
     @Column(name = "github_url", unique = true)
     private String githubUrl;
@@ -54,6 +55,7 @@ public class Repo extends BaseEntity {
     private LocalDateTime lastGithubUpdate;
 
     @OneToMany(mappedBy = "repo", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
     private List<Issue> issues = new ArrayList<>();
 
     @OneToMany(mappedBy = "repo", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/repository/RepoRepository.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/repository/RepoRepository.java
@@ -1,5 +1,6 @@
 package com.chungang.capstone.openstep.domain.Repo.repository;
 
+import com.chungang.capstone.openstep.domain.Issue.entity.Issue;
 import com.chungang.capstone.openstep.domain.Repo.entity.Repo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,10 +11,12 @@ public interface RepoRepository extends JpaRepository<Repo, Long> {
     List<Repo> findTop10ByOrderByStarsDesc();
     Optional<Repo> findByGithubUrl(String githubUrl);
     Optional<Repo> findByRepoName(String name);
+    Optional<Repo> findByOwnerNameAndRepoName(String name, String owner);
 
     List<Repo> findTop10ByRepoNameContainingIgnoreCaseOrDescriptionContainingIgnoreCaseOrderByStarsDesc(
             String nameKeyword, String descKeyword
     );
+
 
 }
 

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoCacheService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoCacheService.java
@@ -17,9 +17,9 @@ public class RepoCacheService {
     private final RedisTemplate<String, String> redisTemplate;
     private final ObjectMapper objectMapper;
 
-    private final long CACHE_EXPIRE_SECONDS = 60L * 60 * 24 * 60; // 60일 유지
+    private final long CACHE_EXPIRE_SECONDS = 60L * 60 * 24 * 60; // TTL 60일
 
-    // 🔁 사용자별 추천 캐시 (기존 유지)
+    // 사용자별 추천 캐시 (기존 유지)
     public void saveRecommendedRepos(Long memberId, List<Repo> repos) {
         String key = generateMemberKey(memberId);
         try {
@@ -42,7 +42,7 @@ public class RepoCacheService {
         }
     }
 
-    // ✅ 새로운 관심 언어 + 관심 도메인 조합 캐시
+    // 새로운 관심 언어 + 관심 도메인 조합 캐시
     public void saveReposByLanguageAndDomain(String lang, String domain, List<Repo> repos) {
         String key = generateInterestKey(lang, domain);
         try {

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoQueryService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoQueryService.java
@@ -22,7 +22,6 @@ import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @Service
@@ -38,7 +37,6 @@ public class RepoQueryService {
     private final RedisTemplate<String, Object> redisTemplate;
     private final RepoCacheService repoCacheService;
 
-
     public List<Repo> getTrendingRepos() {
         GitHubRepoResponse gitHubRepoResponse = gitHubGraphQLService.fetchTrendingRepositories();
 
@@ -52,7 +50,7 @@ public class RepoQueryService {
         return gitHubRepoResponse.getData().getSearch().getEdges()
                 .stream()
                 .map(edge -> edge.getNode())
-                .filter(node -> node.getOpenIssuesCount() > 0 && node.getGoodFirstIssueCount() > 0)
+                .filter(node -> node.getOpenIssuesCount() > 0 && node.getBeginnerIssueCount() > 0)
                 .map(this::saveIfNotExists)
                 .collect(Collectors.toList());
     }
@@ -83,6 +81,7 @@ public class RepoQueryService {
                 .closedIssues(node.getClosedIssues() != null ? node.getClosedIssues().getTotalCount() : 0)
                 .watchers(node.getWatchers() != null ? node.getWatchers().getTotalCount() : 0)
                 .lastGithubUpdate(node.getUpdatedAt() != null ? OffsetDateTime.parse(node.getUpdatedAt()).toLocalDateTime() : null)
+                .beginnerIssueCount(node.getBeginnerIssueCount())
                 .build();
     }
 
@@ -111,7 +110,6 @@ public class RepoQueryService {
 
         for (String lang : languages) {
             for (String domain : domains) {
-                // 캐시에서 조회
                 List<Repo> cached = repoCacheService.getReposByLanguageAndDomain(lang, domain);
                 if (cached != null) {
                     log.info("Cache Hit: {} + {}", lang, domain);
@@ -119,7 +117,6 @@ public class RepoQueryService {
                     continue;
                 }
 
-                // 캐시에 없으면 GitHub에서 가져옴
                 String query = GitHubQueryBuilder.buildSearchQuery(List.of(lang), List.of(domain));
                 GitHubRepoResponse response = gitHubGraphQLService.searchRepositories(query);
                 List<Repo> parsed = parseResponseAndSave(response).stream().limit(10).toList();
@@ -134,17 +131,12 @@ public class RepoQueryService {
         }
 
         List<Repo> sorted = repoMap.values().stream()
-                .sorted(Comparator.comparingInt(r -> -1 * (r.getStars() + getGoodFirstIssueCountSafe(r.getGithubUrl()))))
-                .limit(10)
+                .sorted(Comparator.comparingInt(r -> -1 * (r.getStars() + r.getBeginnerIssueCount())))
+                .limit(20)
                 .toList();
 
         repoCacheService.saveRecommendedRepos(memberId, sorted);
         return sorted;
-    }
-
-
-    private int getGoodFirstIssueCountSafe(String githubUrl) {
-        return repoRepository.findByGithubUrl(githubUrl).map(Repo::getOpenIssues).orElse(0);
     }
 
     private List<Repo> parseResponseAndSave(GitHubRepoResponse response) {
@@ -155,7 +147,7 @@ public class RepoQueryService {
         List<Node> allNodes = response.getData().getSearch().getEdges().stream().map(GitHubRepoResponse.Edge::getNode).toList();
 
         List<Repo> strictFiltered = allNodes.stream()
-                .filter(node -> node.getGoodFirstIssueCount() >= 5)
+                .filter(node -> node.getBeginnerIssueCount() >= 5)
                 .filter(node -> node.getOpenIssuesCount() > 0)
                 .filter(node -> node.getStargazerCount() < 100000)
                 .filter(node -> isUpdatedWithin6Months(node.getUpdatedAt()))
@@ -165,7 +157,7 @@ public class RepoQueryService {
         if (strictFiltered.size() >= 5) return strictFiltered;
 
         return allNodes.stream()
-                .filter(node -> node.getGoodFirstIssueCount() >= 5)
+                .filter(node -> node.getBeginnerIssueCount() >= 5)
                 .filter(node -> node.getOpenIssuesCount() > 0)
                 .filter(node -> isUpdatedWithin6Months(node.getUpdatedAt()))
                 .map(this::saveIfNotExists)

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoQueryService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoQueryService.java
@@ -111,15 +111,15 @@ public class RepoQueryService {
 
         for (String lang : languages) {
             for (String domain : domains) {
-                // ✅ 캐시에서 조회
+                // 캐시에서 조회
                 List<Repo> cached = repoCacheService.getReposByLanguageAndDomain(lang, domain);
                 if (cached != null) {
-                    log.info("✅ 캐시 히트: {} + {}", lang, domain);
+                    log.info("Cache Hit: {} + {}", lang, domain);
                     cached.forEach(repo -> repoMap.putIfAbsent(repo.getGithubUrl(), repo));
                     continue;
                 }
 
-                // ✅ 캐시에 없으면 GitHub에서 가져옴
+                // 캐시에 없으면 GitHub에서 가져옴
                 String query = GitHubQueryBuilder.buildSearchQuery(List.of(lang), List.of(domain));
                 GitHubRepoResponse response = gitHubGraphQLService.searchRepositories(query);
                 List<Repo> parsed = parseResponseAndSave(response).stream().limit(10).toList();
@@ -138,7 +138,6 @@ public class RepoQueryService {
                 .limit(10)
                 .toList();
 
-        // ✅ member별 캐시 저장 (선택적)
         repoCacheService.saveRecommendedRepos(memberId, sorted);
         return sorted;
     }

--- a/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/ErrorStatus.java
@@ -52,6 +52,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 이슈 관련 에러 3000
     ISSUE_NOT_FOUND(HttpStatus.NOT_FOUND, "ISSUE_3001", "존재하지 않는 이슈입니다."),
+    ISSUE_NO_INTEREST_INFO(HttpStatus.NOT_FOUND, "ISSUE_3002", "관심 이슈 정보가 없습니다."),
 
     // 테스크 관련 에러 4000
     TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "TASK_4001", "존재하지 않는 테스크입니다.");

--- a/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/SuccessStatus.java
@@ -42,6 +42,7 @@ public enum SuccessStatus implements BaseCode {
     ISSUE_GET_TRENDING_OK(HttpStatus.OK, "ISSUE_3001", "트렌딩 이슈 리스트를 성공적으로 조회하였습니다."),
     ISSUE_GET_DETAIL_OK(HttpStatus.OK, "ISSUE_3002", "이슈 상세 정보를 성공적으로 조회하였습니다."),
     ISSUE_SUMMARY_OK(HttpStatus.OK, "ISSUE_3003", "이슈 요약 정보를 성공적으로 조회하였습니다."),
+    ISSUE_GET_SUGGEST_OK(HttpStatus.OK, "ISSUE_3004", "이슈 추천 리스트를 성공적으로 조회하였습니다."),
 
     //테스크 관련 응답
     TASK_ASSIGN_OK(HttpStatus.OK, "TASK_4001", "테스크 할당이 완료되었습니다."),

--- a/src/main/java/com/chungang/capstone/openstep/global/config/SecurityConfig.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
 
                                 // Issue 관련 접근
                                 .requestMatchers("/issues/trending", "/issues/{issue-id}", "/summary/issue/{issue-id}").permitAll()
+                                .requestMatchers("/issues/suggest").permitAll()
 
                                 // 기타 관련 접근
                                 .requestMatchers("/example/**").permitAll()


### PR DESCRIPTION
## #️⃣연관된 이슈
> #73
## 📝작업 내용
> - 사용자 맞춤 이슈 추천 API 구현
> - 관심언어, 분야 기반 레포지토리 먼저 추출 후, Label 필터 및 최근 6개월 내 업데이트된 이슈 기준으로 추천 이슈 20개 반환
> - 반환된 모든 이슈는 summary에 OpenAI 요약 정보 포함
> - 캐싱 적용 (Redis)
<img width="980" alt="스크린샷 2025-05-20 오전 2 39 56" src="https://github.com/user-attachments/assets/abab2170-9083-432b-881a-a1ee6964368f" />


## 🔎코드 설명 및 참고 사항
> 

## 💬리뷰 요구사항
>
