### PR TITLE
Refactor: 북마크 설정, 삭제, 조회 API의 대상을 레포지토리에서 이슈로 변경

### DIFF
--- a/src/main/java/com/chungang/capstone/openstep/domain/Bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Bookmark/controller/BookmarkController.java
@@ -19,31 +19,31 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/bookmark")
 @Slf4j
-@Tag(name = "레포지토리 북마크 API", description = "레포지토리 북마크 추가/삭제 관련 API입니다.")
+@Tag(name = "이슈 북마크 API", description = "이슈 북마크 추가/삭제 관련 API입니다.")
 public class BookmarkController {
     private final BookmarkCommandService bookmarkCommandService;
     private final BookmarkQueryService bookmarkQueryService;
 
-    // 레포지토리 북마크 설정
+    // 이슈 북마크 설정
     @PostMapping("/add/{member-id}/{repo-id}")
-    @Operation(summary = "레포지토리 북마크 설정 API", description = "특정 오픈소스 레포지토리를 북마크합니다.")
-    public ApiResponse<BookmarkResponseDTO.CreateBookmarkResultDTO> createBookmark(@PathVariable("member-id") Long memberId, @PathVariable("repo-id") Long repoId) {
-        Bookmark bookmark = bookmarkCommandService.createBookmark(memberId, repoId);
+    @Operation(summary = "이슈 북마크 설정 API", description = "특정 오픈소스 이슈를 북마크합니다.")
+    public ApiResponse<BookmarkResponseDTO.CreateBookmarkResultDTO> createBookmark(@PathVariable("member-id") Long memberId, @PathVariable("issue-id") Long issueId) {
+        Bookmark bookmark = bookmarkCommandService.createBookmark(memberId, issueId);
         return ApiResponse.onSuccess(SuccessStatus.REPO_ADD_BOOKMARK_OK, BookmarkConverter.toCreateBookmarkResultDTO(bookmark));
     }
 
-    // 레포지토리 북마크 삭제
+    // 이슈 북마크 삭제
     @DeleteMapping("/delete/{member-id}/{repo-id}")
-    @Operation(summary = "레포지토리 북마크 삭제 API", description = "특정 오픈소스 레포지토리의 북마크를 해제합니다.")
-    public ApiResponse<BookmarkResponseDTO.DeleteBookmarkResultDTO> deleteBookmark(@PathVariable("member-id") Long memberId, @PathVariable("repo-id") Long repoId) {
-        Long bookmarkId = bookmarkQueryService.findBookmarkIdByMemberAndRepo(memberId, repoId);
+    @Operation(summary = "이슈 북마크 삭제 API", description = "특정 오픈소스 이슈의 북마크를 해제합니다.")
+    public ApiResponse<BookmarkResponseDTO.DeleteBookmarkResultDTO> deleteBookmark(@PathVariable("member-id") Long memberId, @PathVariable("issue-id") Long issueId) {
+        Long bookmarkId = bookmarkQueryService.findBookmarkIdByMemberAndIssue(memberId, issueId);
         bookmarkCommandService.deleteBookmark(bookmarkId);
         return ApiResponse.onSuccess(SuccessStatus.REPO_DELETE_BOOKMARK_OK, BookmarkConverter.toDeleteBookmarkResultDTO(bookmarkId));
     }
 
-    // 사용자가 북마크한 레포지토리 리스트 조회
+    // 사용자가 북마크한 이슈 리스트 조회
     @GetMapping("/list/{member-id}")
-    @Operation(summary = "사용자가 북마크한 레포지토리 리스트 조회 API", description = "특정 사용자가 북마크한 레포지토리 리스트를 조회합니다.")
+    @Operation(summary = "사용자가 북마크한 이슈 리스트 조회 API", description = "특정 사용자가 북마크한 이슈 리스트를 조회합니다.")
     public ApiResponse<BookmarkResponseDTO.BookmarkPreviewListDTO> getBookmarkList(@PathVariable("member-id") Long memberId) {
         List<Bookmark> bookmarkList = bookmarkQueryService.getBookmarkList(memberId);
         return ApiResponse.onSuccess(SuccessStatus.REPO_BOOKMARK_LIST_OK, BookmarkConverter.toBookmarkPreviewListDTO(bookmarkList));

--- a/src/main/java/com/chungang/capstone/openstep/domain/Bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Bookmark/controller/BookmarkController.java
@@ -5,8 +5,10 @@ import com.chungang.capstone.openstep.domain.Bookmark.converter.BookmarkConverte
 import com.chungang.capstone.openstep.domain.Bookmark.entity.Bookmark;
 import com.chungang.capstone.openstep.domain.Bookmark.service.BookmarkCommandService;
 import com.chungang.capstone.openstep.domain.Bookmark.service.BookmarkQueryService;
+import com.chungang.capstone.openstep.domain.Member.entity.Member;
 import com.chungang.capstone.openstep.global.apiPayload.ApiResponse;
 import com.chungang.capstone.openstep.global.apiPayload.code.status.SuccessStatus;
+import com.chungang.capstone.openstep.global.security.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -25,27 +27,30 @@ public class BookmarkController {
     private final BookmarkQueryService bookmarkQueryService;
 
     // 이슈 북마크 설정
-    @PostMapping("/add/{member-id}/{repo-id}")
+    @PostMapping("/add/{issue-id}")
     @Operation(summary = "이슈 북마크 설정 API", description = "특정 오픈소스 이슈를 북마크합니다.")
-    public ApiResponse<BookmarkResponseDTO.CreateBookmarkResultDTO> createBookmark(@PathVariable("member-id") Long memberId, @PathVariable("issue-id") Long issueId) {
-        Bookmark bookmark = bookmarkCommandService.createBookmark(memberId, issueId);
+    public ApiResponse<BookmarkResponseDTO.CreateBookmarkResultDTO> createBookmark(@PathVariable("issue-id") Long issueId) {
+        Member member = SecurityUtils.getCurrentMember();
+        Bookmark bookmark = bookmarkCommandService.createBookmark(member.getMemberId(), issueId);
         return ApiResponse.onSuccess(SuccessStatus.REPO_ADD_BOOKMARK_OK, BookmarkConverter.toCreateBookmarkResultDTO(bookmark));
     }
 
     // 이슈 북마크 삭제
-    @DeleteMapping("/delete/{member-id}/{repo-id}")
+    @DeleteMapping("/delete/{issue-id}")
     @Operation(summary = "이슈 북마크 삭제 API", description = "특정 오픈소스 이슈의 북마크를 해제합니다.")
-    public ApiResponse<BookmarkResponseDTO.DeleteBookmarkResultDTO> deleteBookmark(@PathVariable("member-id") Long memberId, @PathVariable("issue-id") Long issueId) {
-        Long bookmarkId = bookmarkQueryService.findBookmarkIdByMemberAndIssue(memberId, issueId);
+    public ApiResponse<BookmarkResponseDTO.DeleteBookmarkResultDTO> deleteBookmark(@PathVariable("issue-id") Long issueId) {
+        Member member = SecurityUtils.getCurrentMember();
+        Long bookmarkId = bookmarkQueryService.findBookmarkIdByMemberAndIssue(member.getMemberId(), issueId);
         bookmarkCommandService.deleteBookmark(bookmarkId);
         return ApiResponse.onSuccess(SuccessStatus.REPO_DELETE_BOOKMARK_OK, BookmarkConverter.toDeleteBookmarkResultDTO(bookmarkId));
     }
 
     // 사용자가 북마크한 이슈 리스트 조회
-    @GetMapping("/list/{member-id}")
+    @GetMapping("/list/")
     @Operation(summary = "사용자가 북마크한 이슈 리스트 조회 API", description = "특정 사용자가 북마크한 이슈 리스트를 조회합니다.")
-    public ApiResponse<BookmarkResponseDTO.BookmarkPreviewListDTO> getBookmarkList(@PathVariable("member-id") Long memberId) {
-        List<Bookmark> bookmarkList = bookmarkQueryService.getBookmarkList(memberId);
+    public ApiResponse<BookmarkResponseDTO.BookmarkPreviewListDTO> getBookmarkList() {
+        Member member = SecurityUtils.getCurrentMember();
+        List<Bookmark> bookmarkList = bookmarkQueryService.getBookmarkList(member.getMemberId());
         return ApiResponse.onSuccess(SuccessStatus.REPO_BOOKMARK_LIST_OK, BookmarkConverter.toBookmarkPreviewListDTO(bookmarkList));
     }
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Bookmark/converter/BookmarkConverter.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Bookmark/converter/BookmarkConverter.java
@@ -17,7 +17,9 @@ public class BookmarkConverter {
         return BookmarkResponseDTO.CreateBookmarkResultDTO.builder()
                 .bookmarkId(bookmark.getBookmarkId())
                 .memberId(bookmark.getMember().getMemberId())
+                .repoId(bookmark.getRepo().getRepoId())
                 .issueId(bookmark.getIssue().getIssueId())
+                .issueTitle(bookmark.getIssue().getTitle())
                 .createdAt(LocalDateTime.now())
                 .build();
     }
@@ -26,6 +28,7 @@ public class BookmarkConverter {
         return Bookmark.builder()
                 .member(member)
                 .issue(issue)
+                .repo(issue.getRepo())
                 .build();
     }
 

--- a/src/main/java/com/chungang/capstone/openstep/domain/Bookmark/converter/BookmarkConverter.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Bookmark/converter/BookmarkConverter.java
@@ -2,8 +2,8 @@ package com.chungang.capstone.openstep.domain.Bookmark.converter;
 
 import com.chungang.capstone.openstep.domain.Bookmark.dto.BookmarkResponseDTO;
 import com.chungang.capstone.openstep.domain.Bookmark.entity.Bookmark;
+import com.chungang.capstone.openstep.domain.Issue.entity.Issue;
 import com.chungang.capstone.openstep.domain.Member.entity.Member;
-import com.chungang.capstone.openstep.domain.Repo.entity.Repo;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,15 +17,15 @@ public class BookmarkConverter {
         return BookmarkResponseDTO.CreateBookmarkResultDTO.builder()
                 .bookmarkId(bookmark.getBookmarkId())
                 .memberId(bookmark.getMember().getMemberId())
-                .repoId(bookmark.getRepo().getRepoId())
+                .issueId(bookmark.getIssue().getIssueId())
                 .createdAt(LocalDateTime.now())
                 .build();
     }
     // Service
-    public static Bookmark toBookmark(Member member, Repo repo) {
+    public static Bookmark toBookmark(Member member, Issue issue) {
         return Bookmark.builder()
                 .member(member)
-                .repo(repo)
+                .issue(issue)
                 .build();
     }
 
@@ -40,14 +40,17 @@ public class BookmarkConverter {
         return BookmarkResponseDTO.BookmarkPreviewDTO.builder()
                 .memberId(bookmark.getMember().getMemberId())
                 .bookmarkId(bookmark.getBookmarkId())
+                .issueId(bookmark.getIssue().getIssueId())
+                .issueTitle(bookmark.getIssue().getTitle())
                 .repoId(bookmark.getRepo().getRepoId())
                 .repoName(bookmark.getRepo().getRepoName())
+                .ownerName(bookmark.getRepo().getOwnerName())
                 .language(bookmark.getRepo().getLanguage())
                 .stars(bookmark.getRepo().getStars())
-                .forks(bookmark.getRepo().getForks())
                 .githubUrl(bookmark.getRepo().getGithubUrl())
                 .isBookmarked(true)
                 .createdAt(bookmark.getCreatedAt())
+                .updatedAt(bookmark.getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/com/chungang/capstone/openstep/domain/Bookmark/dto/BookmarkResponseDTO.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Bookmark/dto/BookmarkResponseDTO.java
@@ -16,7 +16,9 @@ public class BookmarkResponseDTO {
     public static class CreateBookmarkResultDTO {
         Long bookmarkId;
         Long memberId;
+        Long repoId;
         Long issueId;
+        String issueTitle;
         LocalDateTime createdAt;
     }
 

--- a/src/main/java/com/chungang/capstone/openstep/domain/Bookmark/dto/BookmarkResponseDTO.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Bookmark/dto/BookmarkResponseDTO.java
@@ -16,7 +16,7 @@ public class BookmarkResponseDTO {
     public static class CreateBookmarkResultDTO {
         Long bookmarkId;
         Long memberId;
-        Long repoId;
+        Long issueId;
         LocalDateTime createdAt;
     }
 
@@ -37,14 +37,17 @@ public class BookmarkResponseDTO {
     public static class BookmarkPreviewDTO {
         private Long memberId;
         private Long bookmarkId;
+        private Long issueId;
         private Long repoId;
         private String repoName;
+        private String ownerName;
+        private String issueTitle;
         private String language;
         private Integer stars;
-        private Integer forks;
         private String githubUrl;
         private boolean isBookmarked;
         private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
     }
 
     @Builder

--- a/src/main/java/com/chungang/capstone/openstep/domain/Bookmark/entity/Bookmark.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Bookmark/entity/Bookmark.java
@@ -1,5 +1,6 @@
 package com.chungang.capstone.openstep.domain.Bookmark.entity;
 
+import com.chungang.capstone.openstep.domain.Issue.entity.Issue;
 import com.chungang.capstone.openstep.domain.Member.entity.Member;
 import com.chungang.capstone.openstep.domain.Repo.entity.Repo;
 import com.chungang.capstone.openstep.domain.common.BaseEntity;
@@ -30,6 +31,10 @@ public class Bookmark extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "repo_id", nullable = false)
     private Repo repo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "issue_id", nullable = false)
+    private Issue issue;
 
 
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Bookmark/repository/BookmarkRepository.java
@@ -1,8 +1,8 @@
 package com.chungang.capstone.openstep.domain.Bookmark.repository;
 
 import com.chungang.capstone.openstep.domain.Bookmark.entity.Bookmark;
+import com.chungang.capstone.openstep.domain.Issue.entity.Issue;
 import com.chungang.capstone.openstep.domain.Member.entity.Member;
-import com.chungang.capstone.openstep.domain.Repo.entity.Repo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,10 +11,10 @@ import java.util.List;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     // 북마크 중복 확인
-    boolean existsByMemberAndRepo(Member member, Repo repo);
+    boolean existsByMemberAndIssue(Member member, Issue issue);
 
     List<Bookmark> findAllByMember(Member member);
 
-    @Query("SELECT b.bookmarkId FROM Bookmark b WHERE b.member.memberId = :memberId AND b.repo.repoId = :repoId")
-    Long findBookmarkIdByMemberAndRepo(@Param("memberId") Long memberId, @Param("repoId") Long repoId);
+    @Query("SELECT b.bookmarkId FROM Bookmark b WHERE b.member.memberId = :memberId AND b.issue.issueId = :issueId")
+    Long findBookmarkIdByMemberAndIssue(@Param("memberId") Long memberId, @Param("issueId") Long issueId);
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Bookmark/service/BookmarkCommandService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Bookmark/service/BookmarkCommandService.java
@@ -3,10 +3,10 @@ package com.chungang.capstone.openstep.domain.Bookmark.service;
 import com.chungang.capstone.openstep.domain.Bookmark.converter.BookmarkConverter;
 import com.chungang.capstone.openstep.domain.Bookmark.entity.Bookmark;
 import com.chungang.capstone.openstep.domain.Bookmark.repository.BookmarkRepository;
+import com.chungang.capstone.openstep.domain.Issue.entity.Issue;
+import com.chungang.capstone.openstep.domain.Issue.repository.IssueRepository;
 import com.chungang.capstone.openstep.domain.Member.entity.Member;
 import com.chungang.capstone.openstep.domain.Member.repository.MemberRepository;
-import com.chungang.capstone.openstep.domain.Repo.entity.Repo;
-import com.chungang.capstone.openstep.domain.Repo.repository.RepoRepository;
 import com.chungang.capstone.openstep.global.apiPayload.code.status.ErrorStatus;
 import com.chungang.capstone.openstep.global.apiPayload.exception.GeneralException;
 import jakarta.transaction.Transactional;
@@ -22,22 +22,22 @@ public class BookmarkCommandService {
 
     private final BookmarkRepository bookmarkRepository;
     private final MemberRepository memberRepository;
-    private final RepoRepository repoRepository;
+    private final IssueRepository issueRepository;
 
-    public Bookmark createBookmark(Long memberId, Long repoId) {
+    public Bookmark createBookmark(Long memberId, Long issueId) {
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
-        Repo repo = repoRepository.findById(repoId).orElseThrow(() -> new GeneralException(ErrorStatus.REPO_NOT_FOUND));
+        Issue issue = issueRepository.findById(issueId).orElseThrow(() -> new GeneralException(ErrorStatus.ISSUE_NOT_FOUND));
         // 중복 북마크 방지
-        if (bookmarkRepository.existsByMemberAndRepo(member, repo)) {
-            throw new GeneralException(ErrorStatus.REPO_BOOKMARK_DUPLICATE);
+        if (bookmarkRepository.existsByMemberAndIssue(member, issue)) {
+            throw new GeneralException(ErrorStatus.ISSUE_BOOKMARK_DUPLICATE);
         }
-        Bookmark bookmark = BookmarkConverter.toBookmark(member, repo);
+        Bookmark bookmark = BookmarkConverter.toBookmark(member, issue);
         return bookmarkRepository.save(bookmark);
     }
 
     // 북마크 삭제
     public void deleteBookmark(Long bookmarkId) {
-        Bookmark bookmark = bookmarkRepository.findById(bookmarkId).orElseThrow(() -> new GeneralException(ErrorStatus.REPO_BOOKMARK_NOT_FOUND));
+        Bookmark bookmark = bookmarkRepository.findById(bookmarkId).orElseThrow(() -> new GeneralException(ErrorStatus.ISSUE_BOOKMARK_NOT_FOUND));
         bookmarkRepository.delete(bookmark);
     }
 

--- a/src/main/java/com/chungang/capstone/openstep/domain/Bookmark/service/BookmarkQueryService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Bookmark/service/BookmarkQueryService.java
@@ -21,8 +21,8 @@ public class BookmarkQueryService {
     private final BookmarkRepository bookmarkRepository;
     private final MemberRepository memberRepository;
 
-    public Long findBookmarkIdByMemberAndRepo(Long memberId, Long repoId) {
-        return bookmarkRepository.findBookmarkIdByMemberAndRepo(memberId, repoId);
+    public Long findBookmarkIdByMemberAndIssue(Long memberId, Long issueId) {
+        return bookmarkRepository.findBookmarkIdByMemberAndIssue(memberId, issueId);
     }
 
     public List<Bookmark> getBookmarkList(Long memberId) {

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/entity/Issue.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/entity/Issue.java
@@ -1,5 +1,6 @@
 package com.chungang.capstone.openstep.domain.Issue.entity;
 
+import com.chungang.capstone.openstep.domain.Bookmark.entity.Bookmark;
 import com.chungang.capstone.openstep.domain.Repo.entity.Repo;
 import com.chungang.capstone.openstep.domain.Task.entity.Task;
 import com.chungang.capstone.openstep.domain.common.BaseEntity;
@@ -64,6 +65,9 @@ public class Issue extends BaseEntity {
 
     @OneToMany(mappedBy = "issue", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Task> tasks = new ArrayList<>();
+
+    @OneToMany(mappedBy = "issue", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Bookmark> bookmarks = new ArrayList<>();
 
 
     @Override

--- a/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/ErrorStatus.java
@@ -46,13 +46,13 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 레포지토리 관련 에러 2000
     REPO_NOT_FOUND(HttpStatus.NOT_FOUND, "REPO_2001", "존재하지 않는 레포지토리입니다."),
-    REPO_BOOKMARK_DUPLICATE(HttpStatus.CONFLICT, "REPO_2002", "이미 북마크한 레포지토리입니다."),
-    REPO_BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "REPO_2003", "북마크한 레포지토리가 아닙니다."),
-    REPO_NO_INTEREST_INFO(HttpStatus.NOT_FOUND, "REPO_2004", "관심 레포지토리 정보가 없습니다."),
+    REPO_NO_INTEREST_INFO(HttpStatus.NOT_FOUND, "REPO_2002", "관심 레포지토리 정보가 없습니다."),
 
     // 이슈 관련 에러 3000
     ISSUE_NOT_FOUND(HttpStatus.NOT_FOUND, "ISSUE_3001", "존재하지 않는 이슈입니다."),
     ISSUE_NO_INTEREST_INFO(HttpStatus.NOT_FOUND, "ISSUE_3002", "관심 이슈 정보가 없습니다."),
+    ISSUE_BOOKMARK_DUPLICATE(HttpStatus.CONFLICT, "ISSUE_3003", "이미 북마크한 이슈입니다."),
+    ISSUE_BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "ISSUE_3004", "북마크한 이슈가 아닙니다."),
 
     // 테스크 관련 에러 4000
     TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "TASK_4001", "존재하지 않는 테스크입니다."),

--- a/src/main/java/com/chungang/capstone/openstep/global/config/SecurityConfig.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/config/SecurityConfig.java
@@ -49,12 +49,14 @@ public class SecurityConfig {
 
                                 // Repo 관련 접근
                                 .requestMatchers("/repo/trending", "/repo/{repo-id}", "/summary/repo/{repo-id}").permitAll()
-                                .requestMatchers("/bookmark/add/{member-id}/{repo-id}", "/bookmark/delete/{member-id}/{repo-id}", "/bookmark/list/{member-id}").permitAll()
                                 .requestMatchers("/repo/suggest","/repo/search/name").permitAll()
 
                                 // Issue 관련 접근
                                 .requestMatchers("/issues/trending", "/issues/{issue-id}", "/summary/issue/{issue-id}").permitAll()
                                 .requestMatchers("/issues/suggest", "/issues/search/keyword").permitAll()
+
+                                // Bookmark 관련 접근
+                                .requestMatchers("/bookmark/add/{issue-id}", "/bookmark/delete/{issue-id}", "/bookmark/list/").permitAll()
 
                                 // Rank 관련 접근
                                 .requestMatchers("/rank/xp", "/rank/level", "/rank/all").permitAll()


### PR DESCRIPTION
## #️⃣연관된 이슈
> #51 

## 📝작업 내용
> - 북마크 설정, 삭제, 조회 API의 대상을 레포지토리에서 이슈로 변경
> - 엔드포인트 수정 및 memberId를 pathVariable로 받는 부분 수정

## 🔎코드 설명 및 참고 사항
> 북마크 설정, 삭제, 조회 API의 대상을 레포지토리에서 이슈로 변경

## 💬리뷰 요구사항
>
