### PR TITLE
Refactor: 이슈 추천시 관심사 기반 캐시 검증 해시 로직 추가

### DIFF
--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -1,32 +1,36 @@
-#version: '3'
-#
-#services:
-#  app:
-#    build: .
-#    image: harryest/openstep:dev
-#    ports:
-#      - "8081:8080"
-#    environment:
-#      SPRING_DATASOURCE_URL: jdbc:mysql://openstep.cpgoe06g6rjt.ap-northeast-2.rds.amazonaws.com:3306/openstep_db
-#      SPRING_DATASOURCE_USERNAME: root
-#      SPRING_DATASOURCE_PASSWORD: Capstoneteam01!
-#    depends_on:
-#      - redis
-#    networks:
-#      - openstep-network
-#
-#  redis:
-#    image: redis:7.0
-#    container_name: openstep-redis
-#    ports:
-#      - "6379:6379"
-#    networks:
-#      - openstep-network
-#    volumes:
-#      - redis_data:/data
-#
-#networks:
-#  openstep-network:
-#
-#volumes:
-#  redis_data:
+version: '3'
+
+services:
+  app:
+    build: .
+    image: harryest/openstep:dev
+    container_name: openstep-app
+    ports:
+      - "443:443"
+    volumes:
+      - /home/ubuntu/keystore.p12:/app/keystore.p12
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://openstep.cpgoe06g6rjt.ap-northeast-2.rds.amazonaws.com:3306/openstep_db
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: Capstoneteam01!
+    depends_on:
+      - redis
+    networks:
+      - openstep_network
+
+  redis:
+    image: redis:7.0
+    container_name: openstep-redis
+    ports:
+      - "6379:6379"
+    networks:
+      - openstep_network
+    volumes:
+      - redis_data:/data
+
+networks:
+  openstep_network:
+    driver: bridge
+
+volumes:
+  redis_data:

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueCacheService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueCacheService.java
@@ -42,28 +42,28 @@ public class IssueCacheService {
         }
     }
 
-    // 새로운 관심 언어 + 관심 도메인 조합 캐시
-    public void saveIssuesByLanguageAndDomain(String lang, String domain, List<Issue> issues) {
-        String key = generateInterestKey(lang, domain);
-        try {
-            String json = objectMapper.writeValueAsString(issues);
-            redisTemplate.opsForValue().set(key, json, CACHE_EXPIRE_SECONDS, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            throw new RuntimeException("관심조합 Redis 저장 중 오류 발생", e);
-        }
+    // 해시 저장
+    public void saveInterestHash(Long memberId, String hash) {
+        String key = generateInterestHashKey(memberId);
+        redisTemplate.opsForValue().set(key, hash, CACHE_EXPIRE_SECONDS, TimeUnit.SECONDS);
     }
 
-    public List<Issue> getIssuesByLanguageAndDomain(String lang, String domain) {
-        String key = generateInterestKey(lang, domain);
-        String cached = redisTemplate.opsForValue().get(key);
-        if (cached == null) return null;
-
-        try {
-            return objectMapper.readValue(cached, new TypeReference<List<Issue>>() {});
-        } catch (Exception e) {
-            throw new RuntimeException("관심조합 Redis 역직렬화 실패", e);
-        }
+    // 해시 조회
+    public String getInterestHash(Long memberId) {
+        return redisTemplate.opsForValue().get(generateInterestHashKey(memberId));
     }
+
+    // 해시 키 생성
+    private String generateInterestHashKey(Long memberId) {
+        return "recommend:issues:interest-hash:" + memberId;
+    }
+
+    // 필요 시 해시 강제 삭제 (옵션)
+    public void evictInterestHash(Long memberId) {
+        redisTemplate.delete(generateInterestHashKey(memberId));
+    }
+
+
 
     public void evict(Long memberId) {
         redisTemplate.delete(generateMemberKey(memberId));
@@ -77,48 +77,6 @@ public class IssueCacheService {
         return "recommend:issues:interest:" + lang.toLowerCase() + ":" + domain.toLowerCase();
     }
 
-    public void saveIssuesByLanguage(String lang, List<Issue> issues) {
-        String key = "recommend:issues:lang:" + lang.toLowerCase();
-        try {
-            String json = objectMapper.writeValueAsString(issues);
-            redisTemplate.opsForValue().set(key, json, CACHE_EXPIRE_SECONDS, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            throw new RuntimeException("언어 기반 Redis 저장 중 오류 발생", e);
-        }
-    }
 
-    public void saveIssuesByDomain(String domain, List<Issue> issues) {
-        String key = "recommend:issues:domain:" + domain.toLowerCase();
-        try {
-            String json = objectMapper.writeValueAsString(issues);
-            redisTemplate.opsForValue().set(key, json, CACHE_EXPIRE_SECONDS, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            throw new RuntimeException("도메인 기반 Redis 저장 중 오류 발생", e);
-        }
-    }
-
-    public List<Issue> getIssuesByLanguage(String lang) {
-        String key = "recommend:issues:lang:" + lang.toLowerCase();
-        String cached = redisTemplate.opsForValue().get(key);
-        if (cached == null) return null;
-
-        try {
-            return objectMapper.readValue(cached, new TypeReference<List<Issue>>() {});
-        } catch (Exception e) {
-            throw new RuntimeException("언어 기반 Redis 역직렬화 실패", e);
-        }
-    }
-
-    public List<Issue> getIssuesByDomain(String domain) {
-        String key = "recommend:issues:domain:" + domain.toLowerCase();
-        String cached = redisTemplate.opsForValue().get(key);
-        if (cached == null) return null;
-
-        try {
-            return objectMapper.readValue(cached, new TypeReference<List<Issue>>() {});
-        } catch (Exception e) {
-            throw new RuntimeException("도메인 기반 Redis 역직렬화 실패", e);
-        }
-    }
 
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueQueryService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueQueryService.java
@@ -2,7 +2,6 @@ package com.chungang.capstone.openstep.domain.Issue.service;
 
 import com.chungang.capstone.openstep.domain.Github.dto.GitHubIssueResponse;
 import com.chungang.capstone.openstep.domain.Github.service.GitHubGraphQLService;
-import com.chungang.capstone.openstep.domain.Github.util.GitHubQueryBuilder;
 import com.chungang.capstone.openstep.domain.Issue.converter.IssueConverter;
 import com.chungang.capstone.openstep.domain.Issue.dto.IssueResponseDTO;
 import com.chungang.capstone.openstep.domain.Issue.entity.Issue;
@@ -71,11 +70,19 @@ public class IssueQueryService {
         log.info("[ISSUE_RECOMMEND] Start for memberId = {}", memberId);
 
         //issueCacheService.evict(memberId);
+        // 현재 관심사 기반 해시 계산
+        String currentHash = computeInterestHash(memberId);
+        String cachedHash = issueCacheService.getInterestHash(memberId);
         List<Issue> cached = issueCacheService.getRecommendedIssues(memberId);
-        if (cached != null) {
-            log.info("[ISSUE_RECOMMEND] Cache hit: {} issues", cached.size());
+        if (cached != null && currentHash.equals(cachedHash)) {
+            log.info("[ISSUE_RECOMMEND] Cache hit: {} issues (interests same)", cached.size());
             return cached;
         }
+
+        // 관심사 바뀐 경우 캐시 무효화
+        log.info("[ISSUE_RECOMMEND] Interests changed or no cache, regenerating...");
+        issueCacheService.evict(memberId);
+        issueCacheService.evictInterestHash(memberId);
 
         List<Repo> suggestedRepos = repoQueryService.getSuggestedRepos(memberId);
         log.info("[ISSUE_RECOMMEND] Suggested repos count = {}", suggestedRepos.size());
@@ -180,6 +187,10 @@ public class IssueQueryService {
 
         issueCacheService.saveRecommendedIssues(memberId, summarized);
         log.info("[ISSUE_RECOMMEND] Final recommended issues count = {}", summarized.size());
+
+        // 저장
+        issueCacheService.saveRecommendedIssues(memberId, summarized);
+        issueCacheService.saveInterestHash(memberId, currentHash);
         return summarized;
     }
 
@@ -264,6 +275,17 @@ public class IssueQueryService {
         }
         return issues;
     }
+
+    private String computeInterestHash(Long memberId) {
+        List<String> languages = memberLanguageRepository.findLanguagesByMemberId(memberId)
+                .stream().map(InterestLanguage::getLabel).sorted().toList();
+        List<String> domains = memberDomainRepository.findDomainsByMemberId(memberId)
+                .stream().map(InterestDomain::getLabel).sorted().toList();
+
+        String combined = String.join(",", languages) + "|" + String.join(",", domains);
+        return Integer.toHexString(combined.hashCode());  // 문자열 해시 (간결하게)
+    }
+
 
 
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoCacheService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoCacheService.java
@@ -30,17 +30,6 @@ public class RepoCacheService {
         }
     }
 
-    public List<Repo> getRecommendedRepos(Long memberId) {
-        String key = generateMemberKey(memberId);
-        String cached = redisTemplate.opsForValue().get(key);
-        if (cached == null) return null;
-
-        try {
-            return objectMapper.readValue(cached, new TypeReference<List<Repo>>() {});
-        } catch (Exception e) {
-            throw new RuntimeException("Redis 조회 중 역직렬화 실패", e);
-        }
-    }
 
     // 새로운 관심 언어 + 관심 도메인 조합 캐시
     public void saveReposByLanguageAndDomain(String lang, String domain, List<Repo> repos) {

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoQueryService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoQueryService.java
@@ -33,7 +33,6 @@ public class RepoQueryService {
     private final MemberLanguageRepository memberLanguageRepository;
     private final MemberDomainRepository memberDomainRepository;
     private final GitHubGraphQLService gitHubGraphQLService;
-    private final OpenAIService openAIService;
     private final RedisTemplate<String, Object> redisTemplate;
     private final RepoCacheService repoCacheService;
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #73 

## 📝작업 내용
> - 사용자의 관심 언어나 도메인이 변경된 경우, 기존 추천 이슈 캐시가 무효화되도록 로직 수정
> - 관심사 해시를 계산하여 Redis에 저장하고, 기존 해시와 비교하여 캐시 유지 여부 판단

## 🔎코드 설명 및 참고 사항
> - `IssueQueryService#getSuggestedIssues()` 내부에 관심사 해시 비교 로직 추가
> - `IssueCacheService`에 해시 저장/조회/삭제 메서드 추가
> - 기존 캐시 로직에는 영향 없이 캐시 정확도 향상 목적

## 💬리뷰 요구사항
>
