### PR TITLE
Refactor: 사용자 맞춤 이슈 추천 조건 완화 및 로그 개선

### DIFF
--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueQueryService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueQueryService.java
@@ -84,12 +84,13 @@ public class IssueQueryService {
         issueCacheService.evict(memberId);
         issueCacheService.evictInterestHash(memberId);
 
+        //List<Repo> suggestedRepos = repoQueryService.getSuggestedReposBySplitQuery(memberId);
         List<Repo> suggestedRepos = repoQueryService.getSuggestedRepos(memberId);
         log.info("[ISSUE_RECOMMEND] Suggested repos count = {}", suggestedRepos.size());
 
         List<Issue> collectedIssues = new ArrayList<>();
         List<Issue> fallbackIssues = new ArrayList<>();
-        OffsetDateTime threeMonthsAgo = OffsetDateTime.now().minusMonths(3);
+        OffsetDateTime threeMonthsAgo = OffsetDateTime.now().minusMonths(9);
 
         for (Repo repo : suggestedRepos) {
             String owner = repo.getOwnerName();
@@ -103,6 +104,9 @@ public class IssueQueryService {
             }
 
             List<GitHubIssueResponse.IssueNode> nodes = response.getData().getRepository().getIssues().getNodes();
+
+            int repoCollected = 0;
+            int repoFallback = 0;
 
             for (GitHubIssueResponse.IssueNode node : nodes) {
                 OffsetDateTime updatedAt = OffsetDateTime.parse(node.getUpdatedAt());
@@ -144,14 +148,18 @@ public class IssueQueryService {
                         );
                 if (isBeginnerLabel) {
                     collectedIssues.add(issue);
+                    repoCollected++;
                 } else {
                     fallbackIssues.add(issue);
+                    repoFallback++;
                 }
                 if (collectedIssues.size() >= 50) break;
             }
+            log.info("[ISSUE_RECOMMEND] Repo: {} -> Collected: {}, Fallback: {}", name, repoCollected, repoFallback);
             if (collectedIssues.size() >= 50) break;
         }
 
+        // 상위 추천 20개로 구성
         int need = 20;
         List<Issue> top20 = collectedIssues.stream()
                 .sorted(Comparator.comparing(Issue::getUpdatedAt).reversed())
@@ -168,6 +176,7 @@ public class IssueQueryService {
         }
 
         // 요약 + 저장 (중복 방지 포함)
+        log.info("[ISSUE_RECOMMEND] Recommended Issues:");
         List<Issue> summarized = top20.stream()
                 .map(issue -> {
                     String summary;
@@ -179,18 +188,21 @@ public class IssueQueryService {
                         summary = "요약을 생성할 수 없습니다.";
                     }
                     issue.setSummary(summary);
+                    log.info(" - [{}] {} ({})", issue.getIssueId(), issue.getTitle(), issue.getGithubUrl());
+
                     // 중복 저장 방지
                     return issueRepository.findByGithubUrl(issue.getGithubUrl())
                             .orElseGet(() -> issueRepository.save(issue));
                 })
                 .toList();
 
-        issueCacheService.saveRecommendedIssues(memberId, summarized);
-        log.info("[ISSUE_RECOMMEND] Final recommended issues count = {}", summarized.size());
-
-        // 저장
+        // 캐시 저장
         issueCacheService.saveRecommendedIssues(memberId, summarized);
         issueCacheService.saveInterestHash(memberId, currentHash);
+        log.info("[ISSUE_RECOMMEND] Final recommended issues count = {}", summarized.size());
+        if (summarized.size() < 20) {
+            log.warn("[ISSUE_RECOMMEND] WARNING: Recommended issue count below target ({} / 20)", summarized.size());
+        }
         return summarized;
     }
 

--- a/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoQueryService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Repo/service/RepoQueryService.java
@@ -119,7 +119,7 @@ public class RepoQueryService {
 
                 String query = GitHubQueryBuilder.buildSearchQuery(List.of(lang), List.of(domain));
                 GitHubRepoResponse response = gitHubGraphQLService.searchRepositories(query);
-                List<Repo> parsed = parseResponseAndSave(response).stream().limit(10).toList();
+                List<Repo> parsed = parseResponseAndSave(response).stream().limit(30).toList();
 
                 repoCacheService.saveReposByLanguageAndDomain(lang, domain, parsed);
                 parsed.forEach(repo -> repoMap.putIfAbsent(repo.getGithubUrl(), repo));
@@ -135,7 +135,7 @@ public class RepoQueryService {
 
         List<Repo> sorted = repoMap.values().stream()
                 .sorted(Comparator.comparingInt(r -> -1 * (r.getStars() + r.getBeginnerIssueCount())))
-                .limit(20)
+                .limit(30)
                 .toList();
 
         repoCacheService.saveRecommendedRepos(memberId, sorted);
@@ -163,7 +163,7 @@ public class RepoQueryService {
 
         List<Repo> strictFiltered = allNodes.stream()
                 .filter(node -> node.getBeginnerIssueCount() >= 1)
-                .filter(node -> node.getOpenIssuesCount() > 0)
+                //.filter(node -> node.getOpenIssuesCount() > 0)
                 //.filter(node -> node.getStargazerCount() < 100000)
                 .filter(node -> isUpdatedWithin36Months(node.getUpdatedAt()))
                 .map(this::saveIfNotExists)
@@ -173,10 +173,10 @@ public class RepoQueryService {
 
         return allNodes.stream()
                 .filter(node -> node.getBeginnerIssueCount() >= 0)
-                .filter(node -> node.getOpenIssuesCount() > 0)
+                //.filter(node -> node.getOpenIssuesCount() > 0)
                 .filter(node -> isUpdatedWithin36Months(node.getUpdatedAt()))
                 .map(this::saveIfNotExists)
-                .limit(10)
+                .limit(30)
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #73 

## 📝 작업 내용
> 사용자 관심사 기반 이슈 추천 시 필터링 조건을 완화하여 더 많은 이슈가 추천되도록 개선
> - 초보자 이슈 수(beginners ≥ 1) 조건 → beginners ≥ 0으로 완화  
> - 레포지토리 개수 제한 상향 (예: limit 10 → limit 30 등 내부 조정)  
> - 캐시 미스 시 fallback 전략 강화

## 🔎 코드 설명 및 참고 사항
> - `IssueQueryService` 및 `RepoQueryService` 내부 필터 조건 완화  
> - 로그 개선: 필터링 전후 이슈/레포 수량 출력 추가  
> - GitHub GraphQL 응답 필드 오류로 인한 `stargazerCount` 접근 제거 (이슈에는 없음)

## 💬리뷰 요구사항
>
