### PR TITLE
Refactor: 키워드, 언어, 업데이트 기간 필터로 이슈 검색하도록 기능 수정

### DIFF
--- a/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/GitHubIssueResponse.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/GitHubIssueResponse.java
@@ -1,5 +1,7 @@
 package com.chungang.capstone.openstep.domain.Github.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -30,6 +32,7 @@ public class GitHubIssueResponse {
         private String name;
         private Issues issues;
         private Owner owner;
+        private String nameWithOwner;
     }
 
     @Getter
@@ -53,7 +56,11 @@ public class GitHubIssueResponse {
         private int stargazerCount;
         private String createdAt;
         private String updatedAt;
+
+        @JsonIgnore
         private Repository repository;
+        @JsonProperty("repository")
+        private RepoInfo repoInfo;
 
         public int getGoodFirstIssueCount() {
             return goodFirstIssue != null ? goodFirstIssue.getTotalCount() : 0;
@@ -88,4 +95,10 @@ public class GitHubIssueResponse {
         private String avatarUrl;
     }
 
+    @Getter
+    public static class RepoInfo {
+        private String name;
+        private String nameWithOwner;
+        private Owner owner;
+    }
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Github/service/GitHubGraphQLService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Github/service/GitHubGraphQLService.java
@@ -151,6 +151,7 @@ public class GitHubGraphQLService {
                 mergedAt
                 state
                 repository {
+                  name
                   nameWithOwner
                 }
                 closingIssuesReferences(first: 5) {
@@ -240,6 +241,103 @@ public class GitHubGraphQLService {
             throw new GithubGraphQLException(ErrorStatus.GITHUB_GRAPHQL_ERROR);
         }
     }
+
+    // 키워드 이슈 검색
+//    public GitHubIssueResponse searchIssues(String query) {
+//        String finalQuery = String.format("""
+//        {
+//          search(query: "%s", type: ISSUE, first: 30) {
+//            edges {
+//              node {
+//                ... on Issue {
+//                  title
+//                  body
+//                  url
+//                  createdAt
+//                  updatedAt
+//                  author {
+//                    login
+//                    avatarUrl
+//                  }
+//                  labels(first: 20) {
+//                    nodes { name }
+//                  }
+//                }
+//              }
+//            }
+//          }
+//        }
+//    """, query.replace("\"", "\\\""));
+//
+//        HttpHeaders headers = new HttpHeaders();
+//        headers.setContentType(MediaType.APPLICATION_JSON);
+//        headers.setBearerAuth(githubToken);
+//
+//        HttpEntity<GitHubGraphQLRequest> request =
+//                new HttpEntity<>(new GitHubGraphQLRequest(finalQuery), headers);
+//
+//        try {
+//            ResponseEntity<GitHubIssueResponse> response = restTemplate.exchange(
+//                    GITHUB_GRAPHQL_URL, HttpMethod.POST, request, GitHubIssueResponse.class
+//            );
+//
+//            return response.getBody();
+//        } catch (Exception e) {
+//            log.error("GitHub 이슈 검색 실패: {}", e.getMessage(), e);
+//            throw new GithubGraphQLException(ErrorStatus.GITHUB_GRAPHQL_ERROR);
+//        }
+//    }
+
+    public GitHubIssueResponse searchIssues(String query) {
+        String finalQuery = String.format("""
+        {
+          search(query: \"%s\", type: ISSUE, first: 20) {
+            edges {
+              node {
+                ... on Issue {
+                  number
+                  title
+                  body
+                  url
+                  state
+                  createdAt
+                  updatedAt
+                  author {
+                    login
+                    avatarUrl
+                  }
+                  labels(first: 10) {
+                    nodes { name }
+                  }
+                  repository {
+                    name
+                    nameWithOwner
+                  }
+                }
+              }
+            }
+          }
+        }
+        """, query.replace("\"", "\\\""));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(githubToken);
+
+        HttpEntity<GitHubGraphQLRequest> request =
+                new HttpEntity<>(new GitHubGraphQLRequest(finalQuery), headers);
+
+        try {
+            ResponseEntity<GitHubIssueResponse> response = restTemplate.exchange(
+                    GITHUB_GRAPHQL_URL, HttpMethod.POST, request, GitHubIssueResponse.class);
+            return response.getBody();
+        } catch (Exception e) {
+            log.error("GitHub 이슈 검색 실패", e);
+            throw new GithubGraphQLException(ErrorStatus.GITHUB_GRAPHQL_ERROR);
+        }
+    }
+
+
 
 
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/controller/IssueController.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/controller/IssueController.java
@@ -4,6 +4,8 @@ import com.chungang.capstone.openstep.domain.Issue.service.IssueCommandService;
 import com.chungang.capstone.openstep.domain.Issue.service.IssueQueryService;
 import com.chungang.capstone.openstep.domain.Member.entity.Member;
 import com.chungang.capstone.openstep.domain.Task.entity.Task;
+import com.chungang.capstone.openstep.domain.common.InterestLanguage;
+import com.chungang.capstone.openstep.domain.common.UpdatePeriod;
 import com.chungang.capstone.openstep.global.apiPayload.code.status.SuccessStatus;
 import com.chungang.capstone.openstep.global.apiPayload.ApiResponse;
 import com.chungang.capstone.openstep.domain.Issue.converter.IssueConverter;
@@ -74,15 +76,29 @@ public class IssueController {
 	}
 
 	// 키워드로 이슈 검색
+//	@GetMapping("/search/keyword")
+//	@Operation(summary = "키워드로 이슈 검색 API", description = "키워드로 이슈를 검색합니다.")
+//	public ApiResponse<IssueResponseDTO.IssueListDTO> searchIssuesByKeyword(@RequestParam Optional<String> search,
+//																			@RequestParam InterestLanguage interestLanguage) {
+//		Member member = SecurityUtils.getCurrentMember();
+//		List<Issue> issues = issueQueryService.getIssuesByKeyword(Optional.of(search.orElse("")));
+//		List<Long> bookmarkedIds = issueQueryService.getBookmarkedIssueIds(member.getMemberId());
+//		return ApiResponse.onSuccess(SuccessStatus.ISSUE_SEARCH_BY_KEYWORD_OK, IssueConverter.toIssueListDTO(issues, bookmarkedIds));
+//	}
 	@GetMapping("/search/keyword")
-	@Operation(summary = "키워드로 이슈 검색 API", description = "키워드로 트렌딩 또는 추천된 이슈내에서 검색합니다.")
+	@Operation(summary = "키워드 + 필터 기반 이슈 검색", description = "키워드, 언어, 업데이트 기간 필터로 GitHub 이슈를 검색합니다.")
 	public ApiResponse<IssueResponseDTO.IssueListDTO> searchIssuesByKeyword(
-		@RequestParam Optional<String> search) {
+			@RequestParam String search,
+			@RequestParam(required = false) List<InterestLanguage> languages,
+			@RequestParam(required = false) UpdatePeriod updatePeriod
+	) {
 		Member member = SecurityUtils.getCurrentMember();
-		List<Issue> issues = issueQueryService.getIssuesByKeyword(Optional.of(search.orElse("")));
+		List<Issue> issues = issueQueryService.searchGitHubIssuesByKeywordAndFilters(search, languages, updatePeriod);
 		List<Long> bookmarkedIds = issueQueryService.getBookmarkedIssueIds(member.getMemberId());
-		return ApiResponse.onSuccess(SuccessStatus.ISSUE_SEARCH_BY_KEYWORD_OK, IssueConverter.toIssueListDTO(issues, bookmarkedIds));
+		return ApiResponse.onSuccess(SuccessStatus.ISSUE_SEARCH_BY_KEYWORD_OK,
+				IssueConverter.toIssueListDTO(issues, bookmarkedIds));
 	}
+
 
 
 

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/converter/IssueConverter.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/converter/IssueConverter.java
@@ -1,15 +1,17 @@
 package com.chungang.capstone.openstep.domain.Issue.converter;
 
+import com.chungang.capstone.openstep.domain.Github.dto.GitHubIssueResponse;
 import com.chungang.capstone.openstep.domain.Issue.dto.IssueResponseDTO;
 import com.chungang.capstone.openstep.domain.Issue.entity.Issue;
+import com.chungang.capstone.openstep.domain.Repo.entity.Repo;
 import com.chungang.capstone.openstep.domain.Task.entity.Task;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.time.OffsetDateTime;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class IssueConverter {
+
 //    public static List<IssueResponseDTO.TrendingIssueDTO> toTrendingDTOs(List<Issue> issues) {
 //        return issues.stream()
 //                .map(issue -> IssueResponseDTO.TrendingIssueDTO.builder()
@@ -46,6 +48,8 @@ public class IssueConverter {
                             .authorAvatarUrl(issue.getAuthorAvatarUrl())
                             .isBookmarked(isBookmarked)
                             .labels(issue.getLabels())
+                            .repoName(issue.getRepo() != null ? issue.getRepo().getRepoName() : null)
+                            .repoUrl(issue.getRepo() != null ? issue.getRepo().getGithubUrl() : null)
                             .build();
                 })
                 .collect(Collectors.toList());
@@ -66,6 +70,7 @@ public class IssueConverter {
                 .updatedAt(issue.getUpdatedAt() != null ? issue.getUpdatedAt().toString() : null)
                 .labels(issue.getLabels())
                 .url(issue.getGithubUrl())
+                .repoName(issue.getRepo() != null ? issue.getRepo().getRepoName() : null)
                 .build();
     }
 
@@ -95,4 +100,63 @@ public class IssueConverter {
                 .isAssigned(isAlreadyAssigned)
                 .build();
     }
+
+//    public static Issue fromGitHubIssueNode(GitHubIssueResponse.IssueNode node) {
+//        return Issue.builder()
+//                .title(node.getTitle())
+//                .body(Optional.ofNullable(node.getBody()).orElse("내용 없음"))
+//                .summary(null)
+//                .githubUrl(node.getUrl())
+//                .author(node.getAuthor() != null ? node.getAuthor().getLogin() : "unknown")
+//                .authorAvatarUrl(node.getAuthor() != null ? node.getAuthor().getAvatarUrl() : null)
+//                .createdAt(OffsetDateTime.parse(node.getCreatedAt()).toLocalDateTime())
+//                .updatedAt(OffsetDateTime.parse(node.getUpdatedAt()).toLocalDateTime())
+//                .labels(node.getLabels() != null
+//                        ? node.getLabels().getNodes().stream().map(GitHubIssueResponse.LabelNode::getName).toList()
+//                        : Collections.emptyList())
+//                .state("OPEN")
+//                .language(node.getPrimaryLanguage() != null ? node.getPrimaryLanguage().getName() : null)
+//                .build();
+//    }
+
+    public static Issue fromGitHubIssueNode(GitHubIssueResponse.IssueNode node) {
+        GitHubIssueResponse.RepoInfo repoInfo = node.getRepoInfo();
+        if (repoInfo == null) return null;
+
+        String repoName = repoInfo != null ? repoInfo.getName() : null;
+        String ownerName = (repoInfo != null && repoInfo.getOwner() != null)
+                ? repoInfo.getOwner().getLogin() : null;
+
+        String githubUrl = (repoInfo != null && repoInfo.getNameWithOwner() != null)
+                ? "https://github.com/" + repoInfo.getNameWithOwner()
+                : null;
+
+        Repo repo = Repo.builder()
+                .repoName(repoName)
+                .githubUrl(githubUrl)
+                .ownerName(ownerName)
+                .ownerAvatarUrl((repoInfo != null && repoInfo.getOwner() != null)
+                        ? repoInfo.getOwner().getAvatarUrl()
+                        : null)
+                .build();
+
+        return Issue.builder()
+                .title(node.getTitle())
+                .body(Optional.ofNullable(node.getBody()).orElse("내용 없음"))
+                .summary(null)
+                .githubUrl(node.getUrl())
+                .author(node.getAuthor() != null ? node.getAuthor().getLogin() : "unknown")
+                .authorAvatarUrl(node.getAuthor() != null ? node.getAuthor().getAvatarUrl() : null)
+                .createdAt(OffsetDateTime.parse(node.getCreatedAt()).toLocalDateTime())
+                .updatedAt(OffsetDateTime.parse(node.getUpdatedAt()).toLocalDateTime())
+                .labels(node.getLabels() != null
+                        ? node.getLabels().getNodes().stream().map(GitHubIssueResponse.LabelNode::getName).toList()
+                        : Collections.emptyList())
+                .state(node.getState())
+                .language(node.getPrimaryLanguage() != null ? node.getPrimaryLanguage().getName() : null)
+                .repo(repo)
+                .build();
+    }
+
+
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/dto/IssueResponseDTO.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/dto/IssueResponseDTO.java
@@ -25,6 +25,8 @@ public class IssueResponseDTO {
         private String authorAvatarUrl;
         private boolean isBookmarked;
         private List<String> labels;
+        private String repoName;
+        private String repoUrl;
     }
 
 
@@ -46,6 +48,8 @@ public class IssueResponseDTO {
         private String authorAvatarUrl;
         private boolean isBookmarked;
         private List<String> labels;
+        private String repoName;
+        private String repoUrl;
     }
 
     @Builder

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueQueryService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueQueryService.java
@@ -16,6 +16,7 @@ import com.chungang.capstone.openstep.domain.Repo.repository.RepoRepository;
 import com.chungang.capstone.openstep.domain.Repo.service.RepoQueryService;
 import com.chungang.capstone.openstep.domain.common.InterestDomain;
 import com.chungang.capstone.openstep.domain.common.InterestLanguage;
+import com.chungang.capstone.openstep.domain.common.UpdatePeriod;
 import com.chungang.capstone.openstep.global.apiPayload.code.status.ErrorStatus;
 import com.chungang.capstone.openstep.global.apiPayload.exception.handler.IssueHandler;
 import lombok.RequiredArgsConstructor;
@@ -306,7 +307,44 @@ public class IssueQueryService {
                 .collect(Collectors.toList());
     }
 
+    public List<Issue> searchGitHubIssuesByKeywordAndFilters(String keyword, List<InterestLanguage> languages, UpdatePeriod updatePeriod) {
+        String languageQuery = (languages != null && !languages.isEmpty())
+                ? " language:" + languages.stream()
+                .map(InterestLanguage::getLabel)
+                .collect(Collectors.joining(" OR "))
+                : "";
 
+        String fullQuery = keyword + languageQuery;
+
+        GitHubIssueResponse response = gitHubGraphQLService.searchIssues(fullQuery);
+        if (response == null || response.getData() == null) return Collections.emptyList();
+
+        OffsetDateTime threshold = (updatePeriod != null)
+                ? updatePeriod.getThresholdTime()
+                : OffsetDateTime.MIN;
+
+        List<GitHubIssueResponse.Edge> edges = Optional.ofNullable(response.getData())
+                .map(GitHubIssueResponse.Data::getSearch)
+                .map(GitHubIssueResponse.Search::getEdges)
+                .orElse(Collections.emptyList());
+
+        return edges.stream()
+                .map(GitHubIssueResponse.Edge::getNode)
+                .filter(Objects::nonNull)
+                .filter(node -> node.getUpdatedAt() != null)
+                .map(node -> {
+                    try {
+                        OffsetDateTime updatedAt = OffsetDateTime.parse(node.getUpdatedAt());
+                        return updatedAt.isAfter(threshold) ? node : null;
+                    } catch (Exception e) {
+                        return null; // 날짜 파싱 실패 시 무시
+                    }
+                })
+                .filter(Objects::nonNull)
+                .limit(20)
+                .map(IssueConverter::fromGitHubIssueNode)
+                .toList();
+    }
 
 
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Rank/entity/BadgeType.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Rank/entity/BadgeType.java
@@ -1,0 +1,30 @@
+package com.chungang.capstone.openstep.domain.Rank.entity;
+
+public enum BadgeType {
+    FIRST_COMMIT("첫 커밋", "첫 커밋을 생성한 기여자"),
+    DOC_CONTRIBUTOR("문서 기여자", "문서화 기여로 도움을 준 유저"),
+    BUG_HUNTER("버그 헌터", "버그 이슈를 처음으로 발견한 유저"),
+    PR_MASTER("PR 장인", "10회 이상 Pull Request 성공"),
+    CONSISTENT_DEV("지속성의 신", "3일 연속 커밋 성공"),
+    EXPLORER_LV1("탐험가 Lv1", "3개의 다른 레포 기여"),
+    EXPLORER_LV2("탐험가 Lv2", "6개의 다른 레포 기여"),
+    EXPLORER_LV3("탐험가 Lv3", "9개의 다른 레포 기여"),
+    MENTOR("멘토", "다른 사람의 이슈에 피드백 작성"),
+    COLLAB_MASTER("협업 마스터", "여러 팀원과 협업 경험 다수");
+
+    private final String label;
+    private final String description;
+
+    BadgeType(String label, String description) {
+        this.label = label;
+        this.description = description;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/chungang/capstone/openstep/domain/common/UpdatePeriod.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/common/UpdatePeriod.java
@@ -1,0 +1,42 @@
+package com.chungang.capstone.openstep.domain.common;
+
+import java.time.OffsetDateTime;
+
+public enum UpdatePeriod {
+    ONE_WEEK("1주") {
+        @Override
+        public OffsetDateTime getThresholdTime() {
+            return OffsetDateTime.now().minusWeeks(1);
+        }
+    },
+    ONE_MONTH("1개월") {
+        @Override
+        public OffsetDateTime getThresholdTime() {
+            return OffsetDateTime.now().minusMonths(1);
+        }
+    },
+    THREE_MONTHS("3개월") {
+        @Override
+        public OffsetDateTime getThresholdTime() {
+            return OffsetDateTime.now().minusMonths(3);
+        }
+    },
+    ONE_YEAR("1년") {
+        @Override
+        public OffsetDateTime getThresholdTime() {
+            return OffsetDateTime.now().minusYears(1);
+        }
+    };
+
+    private final String label;
+
+    UpdatePeriod(String label) {
+        this.label = label;
+    }
+
+    public abstract OffsetDateTime getThresholdTime();
+
+    public String getLabel() {
+        return label;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #77 

## 📝작업 내용
> 키워드, 언어, 업데이트 기간 필터로 이슈 검색하도록 기능 수정

## 🔎코드 설명 및 참고 사항
> 키워드, 언어, 업데이트 기간 필터로 이슈 검색하도록 기능 수정
<img width="715" alt="스크린샷 2025-06-01 오후 3 33 00" src="https://github.com/user-attachments/assets/4e35a266-0cf6-451c-87b1-68bfc8733fc9" />
<img width="623" alt="스크린샷 2025-06-01 오후 3 33 21" src="https://github.com/user-attachments/assets/f75d3047-a244-4d33-804c-33c534e9d22f" />


## 💬리뷰 요구사항
>
