### PR TITLE
Fix: Redis 연결시 누락된 username 필드 RedisConfig에 추가

### DIFF
--- a/src/main/java/com/chungang/capstone/openstep/global/config/RedisConfig.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/config/RedisConfig.java
@@ -22,6 +22,9 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int port;
 
+    @Value("${spring.data.redis.username:}")
+    private String username;
+
     @Value("${spring.data.redis.password}")
     private String password;
 
@@ -32,7 +35,11 @@ public class RedisConfig {
     public LettuceConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
 
-        if (!password.isBlank()) {
+        if (username != null && !username.isBlank()) {
+            config.setUsername(username);
+        }
+
+        if (password != null && !password.isBlank()) {
             config.setPassword(RedisPassword.of(password));
         }
 
@@ -42,7 +49,8 @@ public class RedisConfig {
             builder.useSsl();
         }
 
-        return new LettuceConnectionFactory(config, builder.build());
+        LettuceClientConfiguration clientConfig = builder.build();
+        return new LettuceConnectionFactory(config, clientConfig);
     }
 
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #10 

## 📝작업 내용
> Redis 연결시 누락된 username 필드 RedisConfig에 추가

## 🔎코드 설명 및 참고 사항
> Redis 연결시 누락된 username 필드 RedisConfig에 추가

## 💬리뷰 요구사항
>
