### PR TITLE
Refactor: 트렌딩 이슈, 사용자 맞춤 이슈, 키워드 검색 이슈 조회시 페이징으로 변횐

### DIFF
--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/controller/IssueController.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/controller/IssueController.java
@@ -16,7 +16,11 @@ import com.chungang.capstone.openstep.global.security.util.SecurityUtils;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,6 +34,7 @@ import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
+@Validated
 @RequestMapping("/issues")
 @Tag(name = "이슈 API", description = "GitHub 이슈 관련 API입니다.")
 public class IssueController {
@@ -40,8 +45,8 @@ public class IssueController {
 	// 트렌딩 이슈 목록 조회 API
 	@GetMapping("/trending")
 	@Operation(summary = "트렌딩 issue 조회 API", description = "현재 인기 있는 트렌딩한 오픈소스 이슈를 조회합니다.")
-	public ApiResponse<IssueResponseDTO.IssueListDTO> getTrendingIssues() {
-		List<Issue> issues = issueQueryService.getTrendingIssues();
+	public ApiResponse<IssueResponseDTO.IssueListDTO> getTrendingIssues(@Parameter(description = "페이지 번호 (0~3)") @RequestParam(defaultValue = "0") @Min(0) @Max(3) int page) {
+		List<Issue> issues = issueQueryService.getTrendingIssues(PageRequest.of(page, 5));
 		Member member = SecurityUtils.getCurrentMemberOrNull();
 		List<Long> bookmarkedIds = (member != null) ? issueQueryService.getBookmarkedIssueIds(member.getMemberId()) : List.of(); // 비로그인시에는 빈 리스트 반환
 		return ApiResponse.onSuccess(SuccessStatus.ISSUE_GET_TRENDING_OK, IssueConverter.toIssueListDTO(issues, bookmarkedIds));
@@ -68,9 +73,9 @@ public class IssueController {
 	// 사용자 맞춤 이슈 추천
 	@GetMapping("/suggest")
 	@Operation(summary = "사용자 맞춤 이슈 추천 API", description = "사용자의 관심사에 맞는 오픈소스 이슈를 추천합니다.")
-	public ApiResponse<IssueResponseDTO.IssueListDTO> suggestIssues() {
+	public ApiResponse<IssueResponseDTO.IssueListDTO> suggestIssues(@Parameter(description = "페이지 번호 (0~3)") @RequestParam(defaultValue = "0") @Min(0) @Max(3) int page) {
 		Member member = SecurityUtils.getCurrentMember();
-		List<Issue> issues = issueQueryService.getSuggestedIssues(member);
+		List<Issue> issues = issueQueryService.getSuggestedIssues(member, PageRequest.of(page, 5));
 		List<Long> bookmarkedIds = issueQueryService.getBookmarkedIssueIds(member.getMemberId());
 		return ApiResponse.onSuccess(SuccessStatus.ISSUE_GET_SUGGEST_OK, IssueConverter.toIssueListDTO(issues, bookmarkedIds));
 	}
@@ -90,10 +95,11 @@ public class IssueController {
 	public ApiResponse<IssueResponseDTO.IssueListDTO> searchIssuesByKeyword(
 			@RequestParam String search,
 			@RequestParam(required = false) List<InterestLanguage> languages,
-			@RequestParam(required = false) UpdatePeriod updatePeriod
+			@RequestParam(required = false) UpdatePeriod updatePeriod,
+			@Parameter(description = "페이지 번호 (0~3)") @RequestParam(defaultValue = "0") @Min(0) @Max(3) int page
 	) {
 		Member member = SecurityUtils.getCurrentMember();
-		List<Issue> issues = issueQueryService.searchGitHubIssuesByKeywordAndFilters(search, languages, updatePeriod);
+		List<Issue> issues = issueQueryService.searchGitHubIssuesByKeywordAndFilters(search, languages, updatePeriod, PageRequest.of(page, 5));
 		List<Long> bookmarkedIds = issueQueryService.getBookmarkedIssueIds(member.getMemberId());
 		return ApiResponse.onSuccess(SuccessStatus.ISSUE_SEARCH_BY_KEYWORD_OK,
 				IssueConverter.toIssueListDTO(issues, bookmarkedIds));

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueCacheService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueCacheService.java
@@ -18,6 +18,7 @@ public class IssueCacheService {
     private final ObjectMapper objectMapper;
 
     private final long CACHE_EXPIRE_SECONDS = 60L * 60 * 24 * 60; // TTL 60일
+    private static final String TRENDING_CACHE_KEY = "trending:issues";
 
     // 사용자별 추천 캐시 (기존 유지)
     public void saveRecommendedIssues(Long memberId, List<Issue> issues) {
@@ -62,6 +63,31 @@ public class IssueCacheService {
     public void evictInterestHash(Long memberId) {
         redisTemplate.delete(generateInterestHashKey(memberId));
     }
+
+
+    public void saveTrendingIssues(List<Issue> issues) {
+        try {
+            String json = objectMapper.writeValueAsString(issues);
+            redisTemplate.opsForValue().set(TRENDING_CACHE_KEY, json, 6, TimeUnit.HOURS);
+        } catch (Exception e) {
+            throw new RuntimeException("트렌딩 이슈 캐싱 실패", e);
+        }
+    }
+
+    public List<Issue> getTrendingIssuesFromCache() {
+        String cached = redisTemplate.opsForValue().get(TRENDING_CACHE_KEY);
+        if (cached == null) return null;
+        try {
+            return objectMapper.readValue(cached, new TypeReference<List<Issue>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("트렌딩 이슈 캐시 역직렬화 실패", e);
+        }
+    }
+
+    public void evictTrendingIssues() {
+        redisTemplate.delete(TRENDING_CACHE_KEY);
+    }
+
 
 
 

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueQueryService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueQueryService.java
@@ -21,6 +21,7 @@ import com.chungang.capstone.openstep.global.apiPayload.code.status.ErrorStatus;
 import com.chungang.capstone.openstep.global.apiPayload.exception.handler.IssueHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -43,9 +44,51 @@ public class IssueQueryService {
     private final MemberDomainRepository memberDomainRepository;
     private final BookmarkRepository bookmarkRepository;
 
-    public List<Issue> getTrendingIssues() {
-        List<Repo> repos = repoRepository.findAll();
+//    public List<Issue> getTrendingIssues(Pageable pageable) {
+//        List<Repo> repos = repoRepository.findAll();
+//        List<Issue> allIssues = new ArrayList<>();
+//        for (Repo repo : repoRepository.findTop10ByOrderByStarsDesc()) {
+//            GitHubIssueResponse res = gitHubGraphQLService.fetchIssuesByRepo(repo.getOwnerName(), repo.getRepoName());
+//            if (res != null && res.getData().getRepository() != null) {
+//                List<Issue> issues = res.getData().getRepository().getIssues().getNodes().stream()
+//                        .map(node -> {
+//                            Optional<Issue> existing = issueRepository.findByGithubUrl(node.getUrl());
+//                            if (existing.isPresent()) {
+//                                Issue issue = existing.get();
+//                                LocalDateTime updated = OffsetDateTime.parse(node.getUpdatedAt()).toLocalDateTime();
+//                                if (issue.getUpdatedAt().isEqual(updated)) return issue; // skip
+//                            }
+//                            return saveIfNotExistsOrUpdate(node, repo);
+//                        })
+//                        .filter(Objects::nonNull)
+//                        .toList();
+//                allIssues.addAll(issues);
+//            }
+//            if (allIssues.size() >= 20) break;
+//        }
+//        List<Issue> top20 = allIssues.stream()
+//                .sorted(Comparator.comparing(Issue::getUpdatedAt).reversed())
+//                .limit(20)
+//                .toList();
+//
+//        int start = (int) pageable.getOffset();
+//        int end = Math.min(start + pageable.getPageSize(), top20.size());
+//        if (start >= end) return List.of();
+//        return top20.subList(start, end);
+//    }
+
+    public List<Issue> getTrendingIssues(Pageable pageable) {
+        List<Issue> cached = issueCacheService.getTrendingIssuesFromCache();
+        if (cached != null && !cached.isEmpty()) {
+            log.info("[TRENDING] Cache hit: {} issues", cached.size());
+            int start = (int) pageable.getOffset();
+            int end = Math.min(start + pageable.getPageSize(), cached.size());
+            return (start >= end) ? List.of() : cached.subList(start, end);
+        }
+
+        log.info("[TRENDING] Cache miss: fetching from GitHub...");
         List<Issue> allIssues = new ArrayList<>();
+
         for (Repo repo : repoRepository.findTop10ByOrderByStarsDesc()) {
             GitHubIssueResponse res = gitHubGraphQLService.fetchIssuesByRepo(repo.getOwnerName(), repo.getRepoName());
             if (res != null && res.getData().getRepository() != null) {
@@ -55,7 +98,7 @@ public class IssueQueryService {
                             if (existing.isPresent()) {
                                 Issue issue = existing.get();
                                 LocalDateTime updated = OffsetDateTime.parse(node.getUpdatedAt()).toLocalDateTime();
-                                if (issue.getUpdatedAt().isEqual(updated)) return issue; // skip
+                                if (issue.getUpdatedAt().isEqual(updated)) return issue;
                             }
                             return saveIfNotExistsOrUpdate(node, repo);
                         })
@@ -64,10 +107,22 @@ public class IssueQueryService {
                 allIssues.addAll(issues);
             }
         }
-        return allIssues;
+
+        // 정렬 및 캐시 저장
+        List<Issue> sorted = allIssues.stream()
+                .sorted(Comparator.comparing(Issue::getUpdatedAt).reversed())
+                .toList();
+
+        issueCacheService.saveTrendingIssues(sorted);
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), sorted.size());
+        return (start >= end) ? List.of() : sorted.subList(start, end);
     }
 
-    public List<Issue> getSuggestedIssues(Member member) {
+
+
+    public List<Issue> getSuggestedIssues(Member member, Pageable pageable) {
         Long memberId = member.getMemberId();
         log.info("[ISSUE_RECOMMEND] Start for memberId = {}", memberId);
 
@@ -78,7 +133,10 @@ public class IssueQueryService {
         List<Issue> cached = issueCacheService.getRecommendedIssues(memberId);
         if (cached != null && currentHash.equals(cachedHash)) {
             log.info("[ISSUE_RECOMMEND] Cache hit: {} issues (interests same)", cached.size());
-            return cached;
+            int start = (int) pageable.getOffset();
+            int end = Math.min(start + pageable.getPageSize(), cached.size());
+            if (start >= end) return List.of();
+            return cached.subList(start, end);
         }
 
         // 관심사 바뀐 경우 캐시 무효화
@@ -205,7 +263,10 @@ public class IssueQueryService {
         if (summarized.size() < 20) {
             log.warn("[ISSUE_RECOMMEND] WARNING: Recommended issue count below target ({} / 20)", summarized.size());
         }
-        return summarized;
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), summarized.size());
+        if (start >= end) return List.of();
+        return summarized.subList(start, end);
     }
 
 
@@ -307,7 +368,12 @@ public class IssueQueryService {
                 .collect(Collectors.toList());
     }
 
-    public List<Issue> searchGitHubIssuesByKeywordAndFilters(String keyword, List<InterestLanguage> languages, UpdatePeriod updatePeriod) {
+    public List<Issue> searchGitHubIssuesByKeywordAndFilters(
+            String keyword,
+            List<InterestLanguage> languages,
+            UpdatePeriod updatePeriod,
+            Pageable pageable
+    ) {
         String languageQuery = (languages != null && !languages.isEmpty())
                 ? " language:" + languages.stream()
                 .map(InterestLanguage::getLabel)
@@ -328,7 +394,7 @@ public class IssueQueryService {
                 .map(GitHubIssueResponse.Search::getEdges)
                 .orElse(Collections.emptyList());
 
-        return edges.stream()
+        List<Issue> filtered = edges.stream()
                 .map(GitHubIssueResponse.Edge::getNode)
                 .filter(Objects::nonNull)
                 .filter(node -> node.getUpdatedAt() != null)
@@ -337,14 +403,21 @@ public class IssueQueryService {
                         OffsetDateTime updatedAt = OffsetDateTime.parse(node.getUpdatedAt());
                         return updatedAt.isAfter(threshold) ? node : null;
                     } catch (Exception e) {
-                        return null; // 날짜 파싱 실패 시 무시
+                        return null;
                     }
                 })
                 .filter(Objects::nonNull)
-                .limit(20)
                 .map(IssueConverter::fromGitHubIssueNode)
+                .limit(20)
                 .toList();
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), filtered.size());
+        if (start >= end) return List.of();
+
+        return filtered.subList(start, end);
     }
+
 
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #42 

## 📝작업 내용
> 트렌딩 이슈, 사용자 맞춤 이슈, 키워드 검색 이슈 조회시 페이징으로 변횐

## 🔎코드 설명 및 참고 사항
> - 트렌딩 이슈, 사용자 맞춤 이슈, 키워드 검색 이슈 조회시 페이징으로 변횐
> - 전체 20개를를 각 페이지당 최대 5개씩 반환하도록 설정

## 💬리뷰 요구사항
>
