### PR TITLE
Feat: GitHub URL 기반 이슈 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/GitHubIssueResponse.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/GitHubIssueResponse.java
@@ -31,6 +31,7 @@ public class GitHubIssueResponse {
     public static class Repository {
         private String name;
         private Issues issues;
+        private IssueNode issue;
         private Owner owner;
         private String nameWithOwner;
     }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Github/service/GitHubGraphQLService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Github/service/GitHubGraphQLService.java
@@ -338,6 +338,67 @@ public class GitHubGraphQLService {
     }
 
 
+    public GitHubIssueResponse.IssueNode fetchIssueByUrl(String url) {
+        // 예: https://github.com/owner/repo/issues/123
+        try {
+            String[] parts = url.split("/");
+            String owner = parts[3];
+            String repo = parts[4];
+            int number = Integer.parseInt(parts[6]);
+
+            String query = String.format("""
+        {
+          repository(owner: "%s", name: "%s") {
+            issue(number: %d) {
+              number
+              title
+              body
+              url
+              state
+              createdAt
+              updatedAt
+              author {
+                login
+                avatarUrl
+              }
+              labels(first: 10) {
+                nodes {
+                  name
+                }
+              }
+              repository {
+                name
+                nameWithOwner
+                owner {
+                  login
+                  avatarUrl
+                }
+              }
+            }
+          }
+        }
+        """, owner, repo, number);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(githubToken);
+
+            HttpEntity<GitHubGraphQLRequest> request = new HttpEntity<>(new GitHubGraphQLRequest(query), headers);
+
+            ResponseEntity<GitHubIssueResponse> response = restTemplate.exchange(
+                    GITHUB_GRAPHQL_URL, HttpMethod.POST, request, GitHubIssueResponse.class
+            );
+
+            GitHubIssueResponse.Repository repoRes = response.getBody().getData().getRepository();
+            if (repoRes != null) return repoRes.getIssue();
+            else return null;
+
+        } catch (Exception e) {
+            log.error("[GraphQL] 이슈 단건 조회 실패", e);
+            throw new GithubGraphQLException(ErrorStatus.GITHUB_GRAPHQL_ERROR);
+        }
+    }
+
 
 
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/controller/IssueController.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/controller/IssueController.java
@@ -1,16 +1,21 @@
 package com.chungang.capstone.openstep.domain.Issue.controller;
 
+import com.chungang.capstone.openstep.domain.Github.dto.GitHubIssueResponse;
+import com.chungang.capstone.openstep.domain.Github.service.GitHubGraphQLService;
 import com.chungang.capstone.openstep.domain.Issue.service.IssueCommandService;
 import com.chungang.capstone.openstep.domain.Issue.service.IssueQueryService;
 import com.chungang.capstone.openstep.domain.Member.entity.Member;
+import com.chungang.capstone.openstep.domain.OpenAI.service.OpenAIService;
 import com.chungang.capstone.openstep.domain.Task.entity.Task;
 import com.chungang.capstone.openstep.domain.common.InterestLanguage;
 import com.chungang.capstone.openstep.domain.common.UpdatePeriod;
+import com.chungang.capstone.openstep.global.apiPayload.code.status.ErrorStatus;
 import com.chungang.capstone.openstep.global.apiPayload.code.status.SuccessStatus;
 import com.chungang.capstone.openstep.global.apiPayload.ApiResponse;
 import com.chungang.capstone.openstep.domain.Issue.converter.IssueConverter;
 import com.chungang.capstone.openstep.domain.Issue.dto.IssueResponseDTO;
 import com.chungang.capstone.openstep.domain.Issue.entity.Issue;
+import com.chungang.capstone.openstep.global.apiPayload.exception.handler.IssueHandler;
 import com.chungang.capstone.openstep.global.security.util.SecurityUtils;
 
 import io.swagger.v3.oas.annotations.Parameter;
@@ -19,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,12 +41,15 @@ import java.util.Optional;
 @RestController
 @RequiredArgsConstructor
 @Validated
+@Slf4j
 @RequestMapping("/issues")
 @Tag(name = "이슈 API", description = "GitHub 이슈 관련 API입니다.")
 public class IssueController {
 
 	private final IssueQueryService issueQueryService;
 	private final IssueCommandService issueCommandService;
+	private final GitHubGraphQLService gitHubGraphQLService;
+	private final OpenAIService openAIService;
 
 	// 트렌딩 이슈 목록 조회 API
 	@GetMapping("/trending")
@@ -104,6 +113,23 @@ public class IssueController {
 		return ApiResponse.onSuccess(SuccessStatus.ISSUE_SEARCH_BY_KEYWORD_OK,
 				IssueConverter.toIssueListDTO(issues, bookmarkedIds));
 	}
+
+	@GetMapping("/detail-by-url")
+	@Operation(summary = "GitHub URL 기반 이슈 상세 조회", description = "검색된 이슈의 GitHub URL로 상세 정보를 조회합니다.")
+	public ApiResponse<IssueResponseDTO.IssueDetailDTO> getIssueDetailByUrl(@RequestParam String url) {
+		GitHubIssueResponse.IssueNode node = gitHubGraphQLService.fetchIssueByUrl(url);
+		if (node == null) throw new IssueHandler(ErrorStatus.ISSUE_NOT_FOUND);
+		Issue issue = IssueConverter.fromGitHubIssueNode(node);
+		try {
+			String raw = openAIService.summarizeIssue(issue.getTitle(), issue.getBody());
+			issue.setSummary(openAIService.rewriteNaturalKorean(raw));
+		} catch (Exception e) {
+			log.warn("[SUMMARY] 요약 실패: {}", url, e);
+			issue.setSummary("요약을 생성할 수 없습니다.");
+		}
+		return ApiResponse.onSuccess(SuccessStatus.ISSUE_GET_DETAIL_OK, IssueConverter.toIssueDetailDTO(issue));
+	}
+
 
 
 

--- a/src/main/java/com/chungang/capstone/openstep/global/config/SecurityConfig.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/config/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
 
                                 // Issue 관련 접근
                                 .requestMatchers("/issues/trending", "/issues/{issue-id}", "/summary/issue/{issue-id}").permitAll()
-                                .requestMatchers("/issues/suggest", "/issues/search/keyword").permitAll()
+                                .requestMatchers("/issues/suggest", "/issues/search/keyword", "/issues/detail-by-url").permitAll()
 
                                 // Bookmark 관련 접근
                                 .requestMatchers("/bookmark/add/{issue-id}", "/bookmark/delete/{issue-id}", "/bookmark/list/").permitAll()


### PR DESCRIPTION
## #️⃣연관된 이슈
> #111

## 📝작업 내용
> - GitHub URL 기반 이슈 상세 조회 API 구현 
> - 키워드와 필터를 통한 이슈 검색 후 특정 이슈를 상세보기 하면, 해당 이슈의 요약과, 전체 내용을 확인 가능
<img width="986" alt="스크린샷 2025-06-04 오후 7 26 05" src="https://github.com/user-attachments/assets/63dfc108-2ac2-42f9-a85c-5b6da028b680" />

## 🔎코드 설명 및 참고 사항
> fetchIssueByUrl(String url)로 GraphQL 쿼리 추가

## 💬리뷰 요구사항
>
