### PR TITLE
Feat: GitHub url로 이슈 조회시, 레포지토리 정보도 함께 조회하도록 추가

### DIFF
--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/controller/IssueController.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/controller/IssueController.java
@@ -115,20 +115,22 @@ public class IssueController {
 	}
 
 	@GetMapping("/detail-by-url")
-	@Operation(summary = "GitHub URL 기반 이슈 상세 조회", description = "검색된 이슈의 GitHub URL로 상세 정보를 조회합니다.")
-	public ApiResponse<IssueResponseDTO.IssueDetailDTO> getIssueDetailByUrl(@RequestParam String url) {
-		GitHubIssueResponse.IssueNode node = gitHubGraphQLService.fetchIssueByUrl(url);
-		if (node == null) throw new IssueHandler(ErrorStatus.ISSUE_NOT_FOUND);
-		Issue issue = IssueConverter.fromGitHubIssueNode(node);
+	@Operation(summary = "GitHub URL 기반 이슈 + 레포 상세 조회", description = "GitHub URL로 이슈의 상세 정보를 조회하고, 이슈가 속한 레포지토리 정보도 함께 제공합니다.")
+	public ApiResponse<IssueResponseDTO.IssueDetailWithRepoDTO> getIssueDetailByUrl(@RequestParam String url) {
+		IssueResponseDTO.IssueDetailWithRepoDTO dto = issueQueryService.getIssueDetailWithRepoByUrl(url);
 		try {
-			String raw = openAIService.summarizeIssue(issue.getTitle(), issue.getBody());
-			issue.setSummary(openAIService.rewriteNaturalKorean(raw));
+			String raw = openAIService.summarizeIssue(dto.getIssue().getTitle(), dto.getIssue().getBody());
+			dto.getIssue().setSummary(openAIService.rewriteNaturalKorean(raw));
 		} catch (Exception e) {
 			log.warn("[SUMMARY] 요약 실패: {}", url, e);
-			issue.setSummary("요약을 생성할 수 없습니다.");
+			dto.getIssue().setSummary("요약을 생성할 수 없습니다.");
 		}
-		return ApiResponse.onSuccess(SuccessStatus.ISSUE_GET_DETAIL_OK, IssueConverter.toIssueDetailDTO(issue));
+		return ApiResponse.onSuccess(SuccessStatus.ISSUE_GET_DETAIL_OK, dto);
 	}
+
+
+
+
 
 
 

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/converter/IssueConverter.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/converter/IssueConverter.java
@@ -1,6 +1,7 @@
 package com.chungang.capstone.openstep.domain.Issue.converter;
 
 import com.chungang.capstone.openstep.domain.Github.dto.GitHubIssueResponse;
+import com.chungang.capstone.openstep.domain.Github.dto.GitHubRepoResponse;
 import com.chungang.capstone.openstep.domain.Issue.dto.IssueResponseDTO;
 import com.chungang.capstone.openstep.domain.Issue.entity.Issue;
 import com.chungang.capstone.openstep.domain.Repo.entity.Repo;
@@ -158,5 +159,77 @@ public class IssueConverter {
                 .build();
     }
 
+
+//    public static IssueResponseDTO.IssueDetailWithRepoDTO toIssueDetailWithRepoDTO(Issue issue, Repo repo) {
+//        IssueResponseDTO.IssueDetailDTO issueDetailDTO = toIssueDetailDTO(issue);
+//
+//        IssueResponseDTO.RepoSummaryDTO repoSummaryDTO = IssueResponseDTO.RepoSummaryDTO.builder()
+//                .repoId(repo.getRepoId())
+//                .repoName(repo.getRepoName())
+//                .summary(repo.getSummary())
+//                .ownerName(repo.getOwnerName())
+//                .ownerAvatarUrl(repo.getOwnerAvatarUrl())
+//                .description(repo.getDescription())
+//                .language(repo.getLanguage())
+//                .stars(repo.getStars())
+//                .watchers(repo.getWatchers())
+//                .forks(repo.getForks())
+//                .openIssues(repo.getOpenIssues())
+//                .closedIssues(repo.getClosedIssues())
+//                .beginnerIssueCount(repo.getBeginnerIssueCount())
+//                .githubUrl(repo.getGithubUrl())
+//                .readmeUrl(repo.getReadmeUrl())
+//                .build();
+//
+//        return IssueResponseDTO.IssueDetailWithRepoDTO.builder()
+//                .issue(issueDetailDTO)
+//                .repo(repoSummaryDTO)
+//                .build();
+//    }
+
+    public static IssueResponseDTO.IssueDetailWithRepoDTO fromGitHubIssueNodeWithRepo(GitHubIssueResponse.IssueNode issueNode, GitHubRepoResponse.Node repoNode) {
+        IssueResponseDTO.IssueDetailDTO issueDetailDTO = IssueResponseDTO.IssueDetailDTO.builder()
+                .issueId(null)
+                .repoId(null)
+                .title(issueNode.getTitle())
+                .body(issueNode.getBody())
+                .summary(null)
+                .language(issueNode.getRepoInfo() != null && issueNode.getRepoInfo().getOwner() != null ? issueNode.getRepoInfo().getOwner().getLogin() : null)
+                .url(issueNode.getUrl())
+                .createdAt(issueNode.getCreatedAt())
+                .updatedAt(issueNode.getUpdatedAt())
+                .author(issueNode.getAuthor() != null ? issueNode.getAuthor().getLogin() : null)
+                .authorAvatarUrl(issueNode.getAuthor() != null ? issueNode.getAuthor().getAvatarUrl() : null)
+                .isBookmarked(false)
+                .labels(issueNode.getLabels() != null
+                        ? issueNode.getLabels().getNodes().stream().map(GitHubIssueResponse.LabelNode::getName).toList()
+                        : List.of())
+                .repoName(issueNode.getRepoInfo() != null ? issueNode.getRepoInfo().getName() : null)
+                .repoUrl(repoNode.getUrl())
+                .build();
+
+        IssueResponseDTO.RepoSummaryDTO repoSummaryDTO = IssueResponseDTO.RepoSummaryDTO.builder()
+                .repoId(null)
+                .repoName(repoNode.getName())
+                .summary(null)
+                .ownerName(repoNode.getOwner() != null ? repoNode.getOwner().getLogin() : null)
+                .ownerAvatarUrl(repoNode.getOwner() != null ? repoNode.getOwner().getAvatarUrl() : null)
+                .description(repoNode.getDescription())
+                .language(repoNode.getPrimaryLanguage() != null ? repoNode.getPrimaryLanguage().getName() : null)
+                .stars(repoNode.getStargazerCount())
+                .watchers(repoNode.getWatchersCount())
+                .forks(repoNode.getForkCount() != null ? repoNode.getForkCount() : 0)
+                .openIssues(repoNode.getOpenIssuesCount())
+                .closedIssues(repoNode.getClosedIssuesCount())
+                .beginnerIssueCount(repoNode.getBeginnerIssueCount())
+                .githubUrl(repoNode.getUrl())
+                .readmeUrl(null)
+                .build();
+
+        return IssueResponseDTO.IssueDetailWithRepoDTO.builder()
+                .issue(issueDetailDTO)
+                .repo(repoSummaryDTO)
+                .build();
+    }
 
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/dto/IssueResponseDTO.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/dto/IssueResponseDTO.java
@@ -1,9 +1,7 @@
 package com.chungang.capstone.openstep.domain.Issue.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
 import java.util.List;
 
 public class IssueResponseDTO {
@@ -32,6 +30,7 @@ public class IssueResponseDTO {
 
     @Getter
     @Builder
+    @Setter
     @AllArgsConstructor
     @NoArgsConstructor
     public static class IssueDetailDTO {
@@ -51,6 +50,38 @@ public class IssueResponseDTO {
         private String repoName;
         private String repoUrl;
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class IssueDetailWithRepoDTO {
+        private IssueDetailDTO issue;
+        private RepoSummaryDTO repo;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class RepoSummaryDTO {
+        private Long repoId;
+        private String repoName;
+        private String summary;
+        private String ownerName;
+        private String ownerAvatarUrl;
+        private String description;
+        private String language;
+        private int stars;
+        private int watchers;
+        private int forks;
+        private int openIssues;
+        private int closedIssues;
+        private int beginnerIssueCount;
+        private String githubUrl;
+        private String readmeUrl;
+    }
+
 
     @Builder
     public record IssueAssignmentDTO(

--- a/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueQueryService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Issue/service/IssueQueryService.java
@@ -2,6 +2,7 @@ package com.chungang.capstone.openstep.domain.Issue.service;
 
 import com.chungang.capstone.openstep.domain.Bookmark.repository.BookmarkRepository;
 import com.chungang.capstone.openstep.domain.Github.dto.GitHubIssueResponse;
+import com.chungang.capstone.openstep.domain.Github.dto.GitHubRepoResponse;
 import com.chungang.capstone.openstep.domain.Github.service.GitHubGraphQLService;
 import com.chungang.capstone.openstep.domain.Issue.converter.IssueConverter;
 import com.chungang.capstone.openstep.domain.Issue.dto.IssueResponseDTO;
@@ -416,6 +417,29 @@ public class IssueQueryService {
         if (start >= end) return List.of();
 
         return filtered.subList(start, end);
+    }
+
+
+    public IssueResponseDTO.IssueDetailWithRepoDTO getIssueDetailWithRepoByUrl(String url) {
+        // 1. 이슈 정보 조회
+        GitHubIssueResponse.IssueNode issueNode = gitHubGraphQLService.fetchIssueByUrl(url);
+        if (issueNode == null) throw new IssueHandler(ErrorStatus.ISSUE_NOT_FOUND);
+
+        // 2. 레포지토리 정보 조회
+        String owner = issueNode.getRepoInfo().getOwner().getLogin();
+        String repo = issueNode.getRepoInfo().getName();
+        GitHubRepoResponse repoResponse = gitHubGraphQLService.searchRepositories(owner + "/" + repo);
+
+        GitHubRepoResponse.Node repoNode = repoResponse.getData().getSearch().getEdges().stream()
+                .map(GitHubRepoResponse.Edge::getNode)
+                .filter(n -> n.getName().equals(repo))
+                .findFirst()
+                .orElseThrow(() -> new IssueHandler(ErrorStatus.REPO_NOT_FOUND));
+
+        // 3. DTO 변환
+        IssueResponseDTO.IssueDetailWithRepoDTO dto = IssueConverter.fromGitHubIssueNodeWithRepo(issueNode, repoNode);
+
+        return dto;
     }
 
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #111 

## 📝작업 내용
> GitHub url로 이슈 조회시, 레포지토리 정보도 함께 조회하도록 추가
<img width="999" alt="스크린샷 2025-06-05 오전 1 05 33" src="https://github.com/user-attachments/assets/177ccad2-18ea-4576-9500-31bd823c51df" />

## 🔎코드 설명 및 참고 사항
> GitHub url로 이슈 조회시, 레포지토리 정보도 함께 조회하도록 추가

## 💬리뷰 요구사항
>
