### PR TITLE
Feat: 로그인한 사용자의 프로필 조회 API 구현

### DIFF
--- a/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/GitHubUserProfile.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/GitHubUserProfile.java
@@ -1,0 +1,32 @@
+package com.chungang.capstone.openstep.domain.Github.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GitHubUserProfile {
+
+    private String login;
+    //private String name;
+    private String email;
+    private String avatarUrl;
+    private String location;
+    private String url;
+
+    private int followersCount;
+    private int followingCount;
+
+    @JsonProperty("followers")
+    private void unpackFollowers(Map<String, Integer> followers) {
+        this.followersCount = followers.get("totalCount");
+    }
+
+    @JsonProperty("following")
+    private void unpackFollowing(Map<String, Integer> following) {
+        this.followingCount = following.get("totalCount");
+    }
+}

--- a/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/GitHubUserProfileResponse.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/GitHubUserProfileResponse.java
@@ -1,0 +1,13 @@
+package com.chungang.capstone.openstep.domain.Github.dto;
+
+import lombok.Data;
+
+@Data
+public class GitHubUserProfileResponse {
+    private ViewerData data;
+
+    @Data
+    public static class ViewerData {
+        private GitHubUserProfile viewer;
+    }
+}

--- a/src/main/java/com/chungang/capstone/openstep/domain/Github/service/GitHubGraphQLService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Github/service/GitHubGraphQLService.java
@@ -2,12 +2,9 @@ package com.chungang.capstone.openstep.domain.Github.service;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
-import com.chungang.capstone.openstep.domain.Github.dto.GitHubGraphQLRequest;
-import com.chungang.capstone.openstep.domain.Github.dto.GitHubIssueResponse;
-import com.chungang.capstone.openstep.domain.Github.dto.GitHubRepoResponse;
-import com.chungang.capstone.openstep.domain.Github.dto.PullRequestResponse;
-import com.chungang.capstone.openstep.domain.Github.dto.PullRequestResponseWrapper;
+import com.chungang.capstone.openstep.domain.Github.dto.*;
 import com.chungang.capstone.openstep.global.apiPayload.code.status.ErrorStatus;
 import com.chungang.capstone.openstep.global.apiPayload.exception.GithubGraphQLException;
 
@@ -398,6 +395,45 @@ public class GitHubGraphQLService {
             throw new GithubGraphQLException(ErrorStatus.GITHUB_GRAPHQL_ERROR);
         }
     }
+
+
+    public GitHubUserProfile fetchAuthenticatedUserProfile(String accessToken) {
+        String query = """
+        {
+          viewer {
+            login
+            avatarUrl
+            email
+            location
+            followers { totalCount }
+            following { totalCount }
+            url
+          }
+        }
+        """;
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<GitHubGraphQLRequest> request = new HttpEntity<>(new GitHubGraphQLRequest(query), headers);
+
+        try {
+            ResponseEntity<GitHubUserProfileResponse> response = restTemplate.exchange(
+                    GITHUB_GRAPHQL_URL, HttpMethod.POST, request, GitHubUserProfileResponse.class
+            );
+
+            return Optional.ofNullable(response.getBody())
+                    .map(GitHubUserProfileResponse::getData)
+                    .map(GitHubUserProfileResponse.ViewerData::getViewer)
+                    .orElseThrow(() -> new GithubGraphQLException(ErrorStatus.GITHUB_GRAPHQL_ERROR));
+
+        } catch (Exception e) {
+            log.error("GitHub 프로필 정보 조회 실패", e);
+            throw new GithubGraphQLException(ErrorStatus.GITHUB_GRAPHQL_ERROR);
+        }
+    }
+
 
 
 

--- a/src/main/java/com/chungang/capstone/openstep/domain/Member/controller/MemberController.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Member/controller/MemberController.java
@@ -2,6 +2,9 @@ package com.chungang.capstone.openstep.domain.Member.controller;
 
 import java.util.List;
 
+import com.chungang.capstone.openstep.domain.Github.dto.GitHubUserProfile;
+import com.chungang.capstone.openstep.domain.Member.converter.MemberConverter;
+import com.chungang.capstone.openstep.domain.Member.entity.Member;
 import com.chungang.capstone.openstep.domain.Member.service.AuthService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
@@ -124,4 +127,29 @@ public class MemberController {
 		List<PullRequestResponse.PullRequestRes> contributions = gitHubGraphQLService.fetchMyPullRequestsWithIssues(githubId);
 		return ApiResponse.onSuccess(SuccessStatus.ISSUE_GET_DETAIL_OK, contributions);
 	}
+
+	@GetMapping("/github/profile/realtime")
+	@Operation(summary = "GitHub 프로필 실시간 조회", description = "GitHub GraphQL API를 통해 실시간으로 프로필 정보를 조회합니다.")
+	public ApiResponse<MemberResponseDTO.GitHubProfileDTO> getGitHubProfileRealtime() {
+		Long memberId = SecurityUtils.getCurrentMemberId();
+		Member member = memberQueryService.getMemberById(memberId);
+		String accessToken = member.getGithubAccessToken();
+
+		GitHubUserProfile profile = gitHubGraphQLService.fetchAuthenticatedUserProfile(accessToken);
+
+		MemberResponseDTO.GitHubProfileDTO dto = MemberResponseDTO.GitHubProfileDTO.builder()
+				.githubId(profile.getLogin())
+				.email(profile.getEmail())
+				.avatarUrl(profile.getAvatarUrl())
+				.location(profile.getLocation())
+				.profileUrl(profile.getUrl())
+				.followersCount(profile.getFollowersCount())
+				.followingCount(profile.getFollowingCount())
+				.build();
+
+		return ApiResponse.onSuccess(SuccessStatus.MEMBER_GET_GITHUB_PROFILE_OK, dto);
+	}
+
+
+
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Member/converter/MemberConverter.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Member/converter/MemberConverter.java
@@ -41,4 +41,17 @@ public class MemberConverter {
 		return member;
 	}
 
+//	public static MemberResponseDTO.GitHubProfileDTO toGitHubProfileDTO(Member member) {
+//		return MemberResponseDTO.GitHubProfileDTO.builder()
+//				.githubId(member.getGithubId())
+//				.email(member.getEmail())
+//				.avatarUrl(member.getProfileImageUrl())
+//				.location(member.getLocation())
+//				.profileUrl(member.getGithubProfileUrl())
+//				.followersCount(member.getFollowersCount() != null ? member.getFollowersCount() : 0)
+//				.followingCount(member.getFollowingCount() != null ? member.getFollowingCount() : 0)
+//				.build();
+//	}
+
+
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Member/dto/MemberResponseDTO.java
@@ -47,4 +47,17 @@ public class MemberResponseDTO {
 			String githubId,
 			Long memberId) {}
 
+
+	@Builder
+	public record GitHubProfileDTO(
+			String githubId,
+			String email,
+			String avatarUrl,
+			String location,
+			String profileUrl,
+			int followersCount,
+			int followingCount
+	) {}
+
+
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Member/entity/Member.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Member/entity/Member.java
@@ -41,6 +41,18 @@ public class Member extends BaseEntity {
 
     private int xp;
 
+//    @Column(nullable = true)
+//    private String location;
+//
+//    @Column(nullable = true)
+//    private String githubProfileUrl;
+//
+//    @Column(nullable = true)
+//    private Integer followersCount;
+//
+//    @Column(nullable = true)
+//    private Integer followingCount;
+
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberLanguage> languages = new ArrayList<>();
 

--- a/src/main/java/com/chungang/capstone/openstep/domain/Member/service/MemberQueryService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Member/service/MemberQueryService.java
@@ -2,6 +2,9 @@ package com.chungang.capstone.openstep.domain.Member.service;
 
 import java.util.List;
 
+import com.chungang.capstone.openstep.domain.Member.entity.Member;
+import com.chungang.capstone.openstep.domain.Member.repository.MemberRepository;
+import com.chungang.capstone.openstep.global.apiPayload.exception.handler.MemberHandler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +16,8 @@ import com.chungang.capstone.openstep.domain.Member.repository.MemberLanguageRep
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import static com.chungang.capstone.openstep.global.apiPayload.code.status.ErrorStatus.MEMBER_NOT_FOUND;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -20,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MemberQueryService {
 	private final MemberDomainRepository memberDomainRepository;
 	private final MemberLanguageRepository memberLanguageRepository;
+	private final MemberRepository memberRepository;
 
 //	public MemberResponseDTO.DomainsRes getDomains(Long memberId) {
 //		List<String> domains=memberDomainRepository.findDomainsByMemberId(memberId);
@@ -39,5 +45,10 @@ public class MemberQueryService {
 	public MemberResponseDTO.LanguagesRes getLanguages(Long memberId) {
 		return MemberConverter.toLanguageRes(
 				memberLanguageRepository.findLanguagesByMemberId(memberId));
+	}
+
+	public Member getMemberById(Long memberId) {
+		return memberRepository.findById(memberId)
+				.orElseThrow(() -> new MemberHandler(MEMBER_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/SuccessStatus.java
@@ -27,6 +27,7 @@ public enum SuccessStatus implements BaseCode {
     MEMBER_LOGIN_OK(HttpStatus.OK, "MEMBER_1006", "유저 로그인에 성공하였습니다."),
     MEMBER_LOGOUT_OK(HttpStatus.OK, "MEMBER_1007", "유저 로그아웃에 성공하였습니다."),
     MEMBER_UPDATE_ACCESS_TOKEN_OK(HttpStatus.OK, "MEMBER_1008", "유저 액세스 토큰 재발급에 성공하였습니다."),
+    MEMBER_GET_GITHUB_PROFILE_OK(HttpStatus.OK, "MEMBER_1009", "유저 깃허브 프로필 조회에 성공하였습니다."),
 
     // 레포지토리 관련 응답
     REPO_GET_TRENDING_OK(HttpStatus.OK, "REPO_2001", "트렌딩 레포지토리 리스트를 성공적으로 조회하였습니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈
> #53 

## 📝작업 내용
> 로그인한 사용자의 프로필 조회 API 구현
<img width="985" alt="스크린샷 2025-06-05 오전 1 35 37" src="https://github.com/user-attachments/assets/2e89e9ee-091e-4341-8670-567769960907" />

## 🔎코드 설명 및 참고 사항
> 로그인한 사용자의 프로필 조회 API 구현

## 💬리뷰 요구사항
>
