### PR TITLE
Refactor:GitHub 상태 동기화 로직 리팩토링 및 책임 분리

### DIFF
--- a/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/GithubTaskInfo.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/GithubTaskInfo.java
@@ -1,0 +1,31 @@
+package com.chungang.capstone.openstep.domain.Github.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class GithubTaskInfo {
+	private final boolean forkExist;
+	private final PullRequestResponse.PullRequestRes pullRequest;
+	private final boolean hasReview;
+
+	public boolean hasPullRequest() {
+		return pullRequest != null;
+	}
+
+	public String getPrUrl() {
+		return hasPullRequest() ? pullRequest.url() : null;
+	}
+	public boolean isPullRequestMerged() {
+		return hasPullRequest() && pullRequest.mergedAt() != null;
+	}
+
+	public boolean isPullRequestClosed() {
+		return hasPullRequest() && "closed".equals(pullRequest.state());
+	}
+
+	public boolean isPullRequestOpen() {
+		return hasPullRequest() && "open".equals(pullRequest.state());
+	}
+}

--- a/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/PullRequestResponse.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Github/dto/PullRequestResponse.java
@@ -10,6 +10,7 @@ public class PullRequestResponse {
 		int number,
 		String state,
 
+		@JsonProperty("html_url")
 		String url,
 
 		@JsonProperty("created_at")

--- a/src/main/java/com/chungang/capstone/openstep/domain/Github/service/GitHubStatusResolverService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Github/service/GitHubStatusResolverService.java
@@ -6,6 +6,7 @@ import com.chungang.capstone.openstep.domain.Member.entity.Member;
 import com.chungang.capstone.openstep.domain.Task.entity.Task;
 import com.chungang.capstone.openstep.domain.Task.entity.TaskStatus;
 
+//더이상 사용 X
 public interface GitHubStatusResolverService {
     TaskStatus resolveStatus(Task task, Member member);
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Github/service/GitHubStatusResolverServiceImpl.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Github/service/GitHubStatusResolverServiceImpl.java
@@ -17,7 +17,7 @@ import com.chungang.capstone.openstep.domain.achievement.event.TaskCompletedEven
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-@Service
+//더이상 사용 X
 @RequiredArgsConstructor
 @Slf4j
 public class GitHubStatusResolverServiceImpl implements GitHubStatusResolverService {

--- a/src/main/java/com/chungang/capstone/openstep/domain/Github/service/GitHubStatusResolverServiceImpl.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Github/service/GitHubStatusResolverServiceImpl.java
@@ -9,6 +9,7 @@ import com.chungang.capstone.openstep.domain.Github.dto.PullRequestResponse;
 import com.chungang.capstone.openstep.domain.Member.entity.Member;
 import com.chungang.capstone.openstep.domain.Task.entity.Task;
 import com.chungang.capstone.openstep.domain.Task.entity.TaskStatus;
+import com.chungang.capstone.openstep.domain.Task.service.TaskCommandService;
 import com.chungang.capstone.openstep.domain.achievement.event.TaskActivityEvent;
 import com.chungang.capstone.openstep.domain.achievement.event.PrCreatedEvent;
 import com.chungang.capstone.openstep.domain.achievement.event.TaskCompletedEvent;
@@ -23,6 +24,7 @@ public class GitHubStatusResolverServiceImpl implements GitHubStatusResolverServ
 
     private final GitHubRestService gitHubRestService;
     private final ApplicationEventPublisher eventPublisher; // 추가
+    private final TaskCommandService taskCommandService; // 추가
 
     @Override
     public TaskStatus resolveStatus(Task task, Member member) {
@@ -52,6 +54,9 @@ public class GitHubStatusResolverServiceImpl implements GitHubStatusResolverServ
             }
             publishEventIfChanged(member, task, oldStatus, newStatus);
             return newStatus;
+        }else{
+            // PR이 존재하는 경우, PR URL 업데이트
+            taskCommandService.updatePrUrl(task, pr);
         }
 
         // 머지 or 반려 여부

--- a/src/main/java/com/chungang/capstone/openstep/domain/Github/service/GithubInfoService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Github/service/GithubInfoService.java
@@ -1,0 +1,44 @@
+package com.chungang.capstone.openstep.domain.Github.service;
+
+import org.springframework.stereotype.Service;
+
+import com.chungang.capstone.openstep.domain.Github.dto.GithubTaskInfo;
+import com.chungang.capstone.openstep.domain.Github.dto.PullRequestResponse;
+import com.chungang.capstone.openstep.domain.Member.entity.Member;
+import com.chungang.capstone.openstep.domain.Task.entity.Task;
+
+import lombok.RequiredArgsConstructor;
+
+//github api 호출만 담당
+@Service
+@RequiredArgsConstructor
+public class GithubInfoService {
+	private final GitHubRestService githubRestService;
+
+	public GithubTaskInfo getGithubTaskInfo(Task task, Member member) {
+		String owner=task.getIssue().getRepo().getOwnerName();
+		String repo=task.getIssue().getRepo().getRepoName();
+		String user=member.getGithubId();
+		String githubToken=member.getGithubAccessToken();
+
+		//1. fork 존재 여부 확인
+		boolean forkExist=githubRestService.doesForkExist(user, repo, githubToken);
+
+		PullRequestResponse.PullRequestRes pr=null;
+		boolean hasReview=false;
+
+		if(forkExist) {
+			//2. PR 존재 여부 확인
+			pr=githubRestService.findPullRequest(owner, repo, task.getBranchName(), user, githubToken);
+			if (pr != null && "open".equals(pr.state())) {
+				hasReview = githubRestService.hasReview(
+					owner, repo, pr.number(), githubToken);
+			}
+		}
+		return GithubTaskInfo.builder()
+			.forkExist(forkExist)
+			.pullRequest(pr)
+			.hasReview(hasReview)
+			.build();
+	}
+}

--- a/src/main/java/com/chungang/capstone/openstep/domain/Task/controller/TaskController.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Task/controller/TaskController.java
@@ -15,6 +15,7 @@ import com.chungang.capstone.openstep.domain.Task.converter.TaskConverter;
 import com.chungang.capstone.openstep.domain.Task.dto.TaskResponseDTO;
 import com.chungang.capstone.openstep.domain.Task.entity.Task;
 import com.chungang.capstone.openstep.domain.Task.entity.TaskStatus;
+import com.chungang.capstone.openstep.domain.Task.service.TaskCommandService;
 import com.chungang.capstone.openstep.domain.Task.service.TaskQueryService;
 import com.chungang.capstone.openstep.global.apiPayload.ApiResponse;
 import com.chungang.capstone.openstep.global.apiPayload.code.status.SuccessStatus;
@@ -31,6 +32,7 @@ import lombok.RequiredArgsConstructor;
 public class TaskController {
 
 	private final TaskQueryService taskQueryService;
+	private final TaskCommandService taskCommandService;
 
 	@Operation(summary = "특정 테스크 상세 조회 API", description = "특정 오픈소스 레포지토리의 기여(테스크) 정보를 조회합니다.")
 	@GetMapping("/{task-id}")
@@ -64,12 +66,13 @@ public class TaskController {
 		@PathVariable("task-id") Long taskId
 	) {
 		Member member = SecurityUtils.getCurrentMember();
-		TaskResponseDTO.Status updatedStatus = taskQueryService.updateTaskStatusToProgress(taskId, member);
+		TaskResponseDTO.Status updatedStatus = taskCommandService.updateTaskStatusToProgress(taskId, member);
 		return ApiResponse.onSuccess(SuccessStatus.TASK_STATUS_UPDATE_OK, updatedStatus);
 	}
 
 
 
+	@Deprecated
 	@Operation(summary = "특정 테스크의 PR URL 업데이트 API", description = "특정 오픈소스 레포지토리의 기여(테스크) PR URL을 업데이트합니다. forked 상태 이외의 상태에서만 가능합니다.")
 	@PatchMapping("/{task-id}/pr")
 	public ApiResponse<TaskResponseDTO.TaskDetail> updatePRUrl (

--- a/src/main/java/com/chungang/capstone/openstep/domain/Task/converter/TaskConverter.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Task/converter/TaskConverter.java
@@ -17,7 +17,8 @@ public class TaskConverter {
 				task.getCreatedAt().toString(),
 				task.getUpdatedAt().toString(),
 				task.getIssue().getIssueId(),
-				task.getIssue().getGithubUrl()
+				task.getIssue().getGithubUrl(),
+				task.getPrUrl()
 		);
 	}
 	public static TaskResponseDTO.TaskBranchName toTaskBranchName(Task task){

--- a/src/main/java/com/chungang/capstone/openstep/domain/Task/dto/TaskResponseDTO.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Task/dto/TaskResponseDTO.java
@@ -31,6 +31,7 @@ public class TaskResponseDTO {
 			String updatedAt,
 			Long issueId,
 			String issueUrl,
+			String prUrl,
 			List<AchievementDTO> achievements
 	) {
 		public static TaskDetail of(
@@ -42,11 +43,12 @@ public class TaskResponseDTO {
 			String createdAt,
 			String updatedAt,
 			Long issueId,
-			String issueUrl
+			String issueUrl,
+			String prUrl
 		) {
 			return new TaskDetail(
 				taskId, title, forkedUrl, status, branchName,
-				createdAt, updatedAt, issueId, issueUrl,
+				createdAt, updatedAt, issueId, issueUrl,prUrl,
 				new ArrayList<>()
 			);
 		}
@@ -55,7 +57,7 @@ public class TaskResponseDTO {
 		public TaskDetail withAchievements(List<AchievementDTO> achievements) {
 			return new TaskDetail(
 				taskId, title, forkedUrl, status, branchName,
-				createdAt, updatedAt, issueId, issueUrl,
+				createdAt, updatedAt, issueId, issueUrl,prUrl,
 				achievements != null ? achievements : new ArrayList<>()
 			);
 		}

--- a/src/main/java/com/chungang/capstone/openstep/domain/Task/entity/Task.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Task/entity/Task.java
@@ -44,17 +44,6 @@ public class Task extends BaseEntity {
     }
 
     public void updatePrUrl(String prUrl) {
-        //url 형식이 올바른지 확인
-        //https://github.com/<owner>/<repo>/pull/<pr-number>
-        if (prUrl == null || !prUrl.matches("https://github\\.com/[^/]+/[^/]+/pull/\\d+")) {
-            //owner, repo 가 Task의 issue와 일치하는지 확인
-            String[] parts = prUrl.split("/");
-            if (parts.length < 5 || !parts[3].equals(issue.getRepo().getOwnerName()) || !parts[4].equals(issue.getRepo().getRepoName())) {
-                throw new TaskException(ErrorStatus.TASK_PR_URL_UPDATE_ERROR_INVALID_URL);
-            }
-
-        }
-
         if (this.status == TaskStatus.FORKED) {
             throw new TaskException(ErrorStatus.TASK_PR_URL_UPDATE_ERROR_EXCEPT_FORKED);
         }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Task/event/TaskStatusChangedForXpEvent.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Task/event/TaskStatusChangedForXpEvent.java
@@ -1,0 +1,15 @@
+package com.chungang.capstone.openstep.domain.Task.event;
+
+import com.chungang.capstone.openstep.domain.Task.entity.TaskStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// XP 부여 전용 이벤트
+@Getter
+@AllArgsConstructor
+public class TaskStatusChangedForXpEvent {
+    private final Long memberId;
+    private final Long taskId;
+    private final TaskStatus newStatus;
+}

--- a/src/main/java/com/chungang/capstone/openstep/domain/Task/event/TaskXpEventListener.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Task/event/TaskXpEventListener.java
@@ -1,0 +1,83 @@
+package com.chungang.capstone.openstep.domain.Task.event;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import com.chungang.capstone.openstep.domain.Member.entity.Member;
+import com.chungang.capstone.openstep.domain.Member.repository.MemberRepository;
+import com.chungang.capstone.openstep.domain.Rank.entity.TaskXpLog;
+import com.chungang.capstone.openstep.domain.Rank.repository.TaskXpLogRepository;
+import com.chungang.capstone.openstep.domain.Rank.service.RankCommandService;
+import com.chungang.capstone.openstep.domain.Task.entity.Task;
+import com.chungang.capstone.openstep.domain.Task.entity.TaskStatus;
+import com.chungang.capstone.openstep.domain.Task.repository.TaskRepository;
+import com.chungang.capstone.openstep.global.apiPayload.code.status.ErrorStatus;
+import com.chungang.capstone.openstep.global.apiPayload.exception.TaskException;
+import com.chungang.capstone.openstep.global.apiPayload.exception.handler.MemberHandler;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TaskXpEventListener {
+    
+    private final TaskRepository taskRepository;
+    private final MemberRepository memberRepository;
+    private final TaskXpLogRepository taskXpLogRepository;
+    private final RankCommandService rankCommandService;
+
+    @EventListener
+    @Transactional
+    public void handleTaskStatusChangedForXp(TaskStatusChangedForXpEvent event) {
+        try {
+            Task task = taskRepository.findById(event.getTaskId())
+                .orElseThrow(() -> new TaskException(ErrorStatus.TASK_NOT_FOUND));
+            
+            Member member = memberRepository.findById(event.getMemberId())
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+            handleXpGranting(member, task, event.getNewStatus());
+            
+        } catch (Exception e) {
+            log.warn("Failed to grant XP for task: {}, member: {}", 
+                event.getTaskId(), event.getMemberId(), e);
+        }
+    }
+
+    private void handleXpGranting(Member member, Task task, TaskStatus newStatus) {
+        // 중복 지급 방지
+        if (taskXpLogRepository.existsByTaskAndStatus(task, newStatus)) return;
+
+        boolean shouldGrant = true;
+        if (newStatus == TaskStatus.PR) {
+            LocalDateTime today = LocalDate.now().atStartOfDay();
+            LocalDateTime tomorrow = today.plusDays(1);
+
+            int prCountToday = taskXpLogRepository.countByMemberAndStatusAndGrantedAtBetween(
+                    member, TaskStatus.PR, today, tomorrow);
+            shouldGrant = prCountToday < 3;
+        }
+
+        // XP 지급
+        if (shouldGrant) {
+            rankCommandService.addXp(member, newStatus.getXp());
+        }
+
+        // 로그 기록
+        TaskXpLog log = TaskXpLog.builder()
+                .task(task)
+                .member(member)
+                .status(newStatus)
+                .xpGranted(shouldGrant)
+                .grantedAt(LocalDateTime.now())
+                .build();
+
+        taskXpLogRepository.save(log);
+    }
+}

--- a/src/main/java/com/chungang/capstone/openstep/domain/Task/service/TaskCommandService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Task/service/TaskCommandService.java
@@ -1,4 +1,51 @@
 package com.chungang.capstone.openstep.domain.Task.service;
 
+import java.util.Objects;
+
+import org.springframework.stereotype.Service;
+
+import com.chungang.capstone.openstep.domain.Github.dto.PullRequestResponse;
+import com.chungang.capstone.openstep.domain.Member.entity.Member;
+import com.chungang.capstone.openstep.domain.Task.converter.TaskConverter;
+import com.chungang.capstone.openstep.domain.Task.dto.TaskResponseDTO;
+import com.chungang.capstone.openstep.domain.Task.entity.Task;
+import com.chungang.capstone.openstep.domain.Task.entity.TaskStatus;
+import com.chungang.capstone.openstep.domain.Task.repository.TaskRepository;
+import com.chungang.capstone.openstep.global.apiPayload.code.status.ErrorStatus;
+import com.chungang.capstone.openstep.global.apiPayload.exception.TaskException;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
 public class TaskCommandService {
+	private final TaskRepository taskRepository;
+	public void updatePrUrl(Task task, PullRequestResponse.PullRequestRes pr) {
+		try {
+			String prUrl = pr.url();
+			if (!Objects.equals(task.getPrUrl(), prUrl)) {
+				task.updatePrUrl(prUrl);
+				log.info("Updated PR URL for task: {}, PR URL: {}", task.getTaskId(), prUrl);
+			}
+		} catch (Exception e) {
+			log.warn("Failed to update PR URL for task: {}", task.getTaskId(), e);
+		}
+		taskRepository.save(task);
+	}
+	public TaskResponseDTO.Status updateTaskStatusToProgress(Long taskId, Member member) {
+		Task task = taskRepository.findById(taskId).orElseThrow(() ->
+			new TaskException(ErrorStatus.TASK_NOT_FOUND));
+
+		if(task.getStatus()!= TaskStatus.FORKED) {
+			throw new TaskException(ErrorStatus.TASK_STATUS_UPDATE_FORBIDDEN);
+		}
+		task.updateStatus(TaskStatus.PROGRESS);
+		taskRepository.save(task);
+
+		return TaskConverter.toTaskStatus(task);
+	}
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Task/service/TaskEventService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Task/service/TaskEventService.java
@@ -1,0 +1,65 @@
+package com.chungang.capstone.openstep.domain.Task.service;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+import com.chungang.capstone.openstep.domain.Member.entity.Member;
+import com.chungang.capstone.openstep.domain.Task.entity.Task;
+import com.chungang.capstone.openstep.domain.Task.entity.TaskStatus;
+import com.chungang.capstone.openstep.domain.achievement.event.PrCreatedEvent;
+import com.chungang.capstone.openstep.domain.achievement.event.TaskActivityEvent;
+import com.chungang.capstone.openstep.domain.achievement.event.TaskCompletedEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TaskEventService {
+
+	private final ApplicationEventPublisher eventPublisher;
+
+	//테스크 상태에 따라 이벤트를 발행해주는 서비스
+
+	public void publishStatusChangeEvent(Member member, Task task, TaskStatus oldStatus, TaskStatus newStatus) {
+		if(oldStatus == newStatus) {
+			return;
+		}
+
+		try {
+			log.info("Publishing events for task status change: {} -> {} for task: {}, user: {}",
+				oldStatus, newStatus, task.getTaskId(), member.getMemberId());
+
+			eventPublisher.publishEvent(new TaskActivityEvent(
+				member.getMemberId(),
+				task.getTaskId(),
+				oldStatus,
+				newStatus
+			));
+
+			//pr 생성시
+			if(newStatus == TaskStatus.PR) {
+				eventPublisher.publishEvent(new PrCreatedEvent(
+					member.getMemberId(),
+					task.getTaskId(),
+					task.getIssue().getTitle(),
+					task.getIssue().getBody()
+				));
+			}
+
+			//task 완료시
+			if(newStatus == TaskStatus.MERGED || newStatus == TaskStatus.REJECTED) {
+				eventPublisher.publishEvent(new TaskCompletedEvent(
+					member.getMemberId(),
+					task.getTaskId(),
+					task.getIssue().getRepo().getRepoName()
+				));
+			}
+		}catch (Exception e) {
+			//업적 발행 실패시 로그만 남기고 넘어감
+			log.warn("Failed to publish achievement event for task: {}, member: {}", task.getTaskId(), member.getMemberId(), e);
+		}
+	}
+
+}

--- a/src/main/java/com/chungang/capstone/openstep/domain/Task/service/TaskEventService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Task/service/TaskEventService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import com.chungang.capstone.openstep.domain.Member.entity.Member;
 import com.chungang.capstone.openstep.domain.Task.entity.Task;
 import com.chungang.capstone.openstep.domain.Task.entity.TaskStatus;
+import com.chungang.capstone.openstep.domain.Task.event.TaskStatusChangedForXpEvent;
 import com.chungang.capstone.openstep.domain.achievement.event.PrCreatedEvent;
 import com.chungang.capstone.openstep.domain.achievement.event.TaskActivityEvent;
 import com.chungang.capstone.openstep.domain.achievement.event.TaskCompletedEvent;
@@ -37,6 +38,9 @@ public class TaskEventService {
 				oldStatus,
 				newStatus
 			));
+
+			eventPublisher.publishEvent(new TaskStatusChangedForXpEvent(
+				member.getMemberId(), task.getTaskId(), newStatus));
 
 			//pr 생성시
 			if(newStatus == TaskStatus.PR) {

--- a/src/main/java/com/chungang/capstone/openstep/domain/Task/service/TaskQueryService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Task/service/TaskQueryService.java
@@ -1,13 +1,10 @@
 package com.chungang.capstone.openstep.domain.Task.service;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
 import com.chungang.capstone.openstep.domain.Github.dto.GithubTaskInfo;
 import com.chungang.capstone.openstep.domain.Github.service.GithubInfoService;
-import com.chungang.capstone.openstep.domain.Rank.entity.TaskXpLog;
 import com.chungang.capstone.openstep.domain.Rank.repository.TaskXpLogRepository;
 import com.chungang.capstone.openstep.domain.Rank.service.RankCommandService;
 
@@ -37,7 +34,6 @@ public class TaskQueryService {
 	private final TaskRepository taskRepository;
 	private final RankCommandService rankCommandService;
 	private final TaskXpLogRepository taskXpLogRepository;
-	private final GitHubStatusResolverService githubStatusResolver;
 	private final AchievementService achievementService;
 	private final GithubInfoService gitHubInfoService;
 	private final TaskStatusResolver taskStatusResolver;
@@ -46,20 +42,7 @@ public class TaskQueryService {
 
 	@Transactional
 	public TaskResponseDTO.TaskDetail getTaskDetailById(Long taskId, Member member) {
-		Task task = taskRepository.findById(taskId).orElseThrow(() ->
-			new TaskException(ErrorStatus.TASK_NOT_FOUND));
-
-		TaskStatus oldStatus = task.getStatus();
-		//github 동기화
-		GithubTaskInfo githubInfo = gitHubInfoService.getGithubTaskInfo(task, member);
-		TaskStatus newStatus = taskStatusResolver.resolveStatus(task, githubInfo);
-
-		boolean updated = taskUpdateService.updateTaskByGithubInfo(task, newStatus, githubInfo);
-
-		if (updated && oldStatus != newStatus) {
-			taskEventService.publishStatusChangeEvent(member, task, oldStatus, newStatus);
-		}
-
+		Task task = syncTaskWithGitHub(taskId, member);
 		TaskResponseDTO.TaskDetail taskDetail = TaskConverter.toTaskDetail(task);
 
 		// 이 Task와 관련된 업적 정보 조회
@@ -77,18 +60,9 @@ public class TaskQueryService {
 		return TaskConverter.toTaskBranchName(task);
 	}
 
+	@Transactional
 	public TaskResponseDTO.Status getStatusByTaskId(Long taskId, Member member) {
-		Task task = taskRepository.findById(taskId).orElseThrow(() ->
-			new TaskException(ErrorStatus.TASK_NOT_FOUND));
-
-		TaskStatus oldStatus = task.getStatus();
-		TaskStatus resolvedStatus = githubStatusResolver.resolveStatus(task, member);
-
-		// DB 캐시 상태가 다르면 update
-		if (oldStatus != resolvedStatus) {
-			task.updateStatus(resolvedStatus);
-			taskRepository.save(task);
-		}
+		Task task = syncTaskWithGitHub(taskId, member);
 		return TaskConverter.toTaskStatus(task);
 	}
 
@@ -170,65 +144,29 @@ public class TaskQueryService {
 //		return updatedTasks;
 //	}
 
+	@Transactional
 	public List<Task> updateAllTaskStatus(Member member) {
 		List<Task> tasks = taskRepository.findAllByMember(member);
 
-		List<Task> updatedTasks = tasks.stream()
+		//github 동기화
+		return tasks.stream()
 				.map(task -> {
 					TaskStatus oldStatus = task.getStatus();
-					TaskStatus resolvedStatus = githubStatusResolver.resolveStatus(task, member);
+					//github 동기화
+					GithubTaskInfo githubInfo = gitHubInfoService.getGithubTaskInfo(task, member);
+					TaskStatus newStatus = taskStatusResolver.resolveStatus(task, githubInfo);
 
+					boolean updated = taskUpdateService.updateTaskByGithubInfo(task, newStatus, githubInfo);
 
-					if (oldStatus!= resolvedStatus) {
-						task.updateStatus(resolvedStatus);
-						Task saved = taskRepository.save(task);
-
-						handleXpGranting(member, saved, resolvedStatus);
-
-
-						return Optional.of(saved);
+					if (updated && oldStatus != newStatus) {
+						taskEventService.publishStatusChangeEvent(member, task, oldStatus, newStatus);
+						return Optional.of(task);
 					}
 					return Optional.<Task>empty();
 				})
 				.flatMap(Optional::stream)
 				.collect(Collectors.toList());
-
-		return updatedTasks;
 	}
-
-
-	private void handleXpGranting(Member member, Task task, TaskStatus newStatus) {
-		// 중복 지급 방지
-		if (taskXpLogRepository.existsByTaskAndStatus(task, newStatus)) return;
-
-		boolean shouldGrant = true;
-		if (newStatus == TaskStatus.PR) {
-			LocalDateTime today = LocalDate.now().atStartOfDay();
-			LocalDateTime tomorrow = today.plusDays(1);
-
-			int prCountToday = taskXpLogRepository.countByMemberAndStatusAndGrantedAtBetween(
-					member, TaskStatus.PR, today, tomorrow);
-			shouldGrant = prCountToday < 3;
-		}
-
-		// XP 지급
-		if (shouldGrant) {
-			rankCommandService.addXp(member, newStatus.getXp());
-		}
-
-		// 로그 기록
-		TaskXpLog log = TaskXpLog.builder()
-				.task(task)
-				.member(member)
-				.status(newStatus)
-				.xpGranted(shouldGrant)
-				.grantedAt(LocalDateTime.now())
-				.build();
-
-		taskXpLogRepository.save(log);
-	}
-
-
 
 	public Map<String, Long> getTaskStatistics(Member member) {
 		List<Task> tasks = taskRepository.findAllByMember(member);
@@ -253,32 +191,27 @@ public class TaskQueryService {
 		return categorizedStatistics;
 	}
 
+	@Deprecated
 	public TaskResponseDTO.TaskDetail updatePRUrl(Long taskId,String prUrl ,Member member) {
-	Task task = taskRepository.findById(taskId).orElseThrow(() ->
-			new TaskException(ErrorStatus.TASK_NOT_FOUND));
-		TaskStatus oldStatus = task.getStatus();
-		TaskStatus resolvedStatus = githubStatusResolver.resolveStatus(task, member);
-
-		// DB 캐시 상태가 다르면 update
-		if (oldStatus != resolvedStatus) {
-			task.updateStatus(resolvedStatus);
-			task = taskRepository.save(task);
-		}
+		Task task = syncTaskWithGitHub(taskId, member);
 		task.updatePrUrl(prUrl);
 		taskRepository.save(task);
 		return TaskConverter.toTaskDetail(task);
 	}
-
-	public TaskResponseDTO.Status updateTaskStatusToProgress(Long taskId, Member member) {
+	private Task syncTaskWithGitHub(Long taskId, Member member) {
 		Task task = taskRepository.findById(taskId).orElseThrow(() ->
 			new TaskException(ErrorStatus.TASK_NOT_FOUND));
 
-		if(task.getStatus()!=TaskStatus.FORKED) {
-			throw new TaskException(ErrorStatus.TASK_STATUS_UPDATE_FORBIDDEN);
-		}
-		task.updateStatus(TaskStatus.PROGRESS);
-		taskRepository.save(task);
+		TaskStatus oldStatus = task.getStatus();
+		//github 동기화
+		GithubTaskInfo githubInfo = gitHubInfoService.getGithubTaskInfo(task, member);
+		TaskStatus newStatus = taskStatusResolver.resolveStatus(task, githubInfo);
 
-		return TaskConverter.toTaskStatus(task);
+		boolean updated = taskUpdateService.updateTaskByGithubInfo(task, newStatus, githubInfo);
+
+		if (updated && oldStatus != newStatus) {
+			taskEventService.publishStatusChangeEvent(member, task, oldStatus, newStatus);
+		}
+		return task;
 	}
 }

--- a/src/main/java/com/chungang/capstone/openstep/domain/Task/service/TaskQueryService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Task/service/TaskQueryService.java
@@ -5,6 +5,8 @@ import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import com.chungang.capstone.openstep.domain.Github.dto.GithubTaskInfo;
+import com.chungang.capstone.openstep.domain.Github.service.GithubInfoService;
 import com.chungang.capstone.openstep.domain.Rank.entity.TaskXpLog;
 import com.chungang.capstone.openstep.domain.Rank.repository.TaskXpLogRepository;
 import com.chungang.capstone.openstep.domain.Rank.service.RankCommandService;
@@ -23,6 +25,7 @@ import com.chungang.capstone.openstep.domain.achievement.service.AchievementServ
 import com.chungang.capstone.openstep.global.apiPayload.code.status.ErrorStatus;
 import com.chungang.capstone.openstep.global.apiPayload.exception.TaskException;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -36,18 +39,25 @@ public class TaskQueryService {
 	private final TaskXpLogRepository taskXpLogRepository;
 	private final GitHubStatusResolverService githubStatusResolver;
 	private final AchievementService achievementService;
+	private final GithubInfoService gitHubInfoService;
+	private final TaskStatusResolver taskStatusResolver;
+	private final TaskUpdateService taskUpdateService;
+	private final TaskEventService taskEventService;
 
+	@Transactional
 	public TaskResponseDTO.TaskDetail getTaskDetailById(Long taskId, Member member) {
 		Task task = taskRepository.findById(taskId).orElseThrow(() ->
 			new TaskException(ErrorStatus.TASK_NOT_FOUND));
 
 		TaskStatus oldStatus = task.getStatus();
-		TaskStatus resolvedStatus = githubStatusResolver.resolveStatus(task, member);
+		//github 동기화
+		GithubTaskInfo githubInfo = gitHubInfoService.getGithubTaskInfo(task, member);
+		TaskStatus newStatus = taskStatusResolver.resolveStatus(task, githubInfo);
 
-		// DB 캐시 상태가 다르면 update
-		if (oldStatus != resolvedStatus) {
-			task.updateStatus(resolvedStatus);
-			taskRepository.save(task);
+		boolean updated = taskUpdateService.updateTaskByGithubInfo(task, newStatus, githubInfo);
+
+		if (updated && oldStatus != newStatus) {
+			taskEventService.publishStatusChangeEvent(member, task, oldStatus, newStatus);
 		}
 
 		TaskResponseDTO.TaskDetail taskDetail = TaskConverter.toTaskDetail(task);
@@ -168,6 +178,7 @@ public class TaskQueryService {
 					TaskStatus oldStatus = task.getStatus();
 					TaskStatus resolvedStatus = githubStatusResolver.resolveStatus(task, member);
 
+
 					if (oldStatus!= resolvedStatus) {
 						task.updateStatus(resolvedStatus);
 						Task saved = taskRepository.save(task);
@@ -253,7 +264,6 @@ public class TaskQueryService {
 			task.updateStatus(resolvedStatus);
 			task = taskRepository.save(task);
 		}
-
 		task.updatePrUrl(prUrl);
 		taskRepository.save(task);
 		return TaskConverter.toTaskDetail(task);

--- a/src/main/java/com/chungang/capstone/openstep/domain/Task/service/TaskStatusResolver.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Task/service/TaskStatusResolver.java
@@ -1,0 +1,44 @@
+package com.chungang.capstone.openstep.domain.Task.service;
+
+import java.util.Objects;
+
+import org.springframework.stereotype.Service;
+
+import com.chungang.capstone.openstep.domain.Github.dto.GithubTaskInfo;
+import com.chungang.capstone.openstep.domain.Github.dto.PullRequestResponse;
+import com.chungang.capstone.openstep.domain.Task.entity.Task;
+import com.chungang.capstone.openstep.domain.Task.entity.TaskStatus;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class TaskStatusResolver {
+	public TaskStatus resolveStatus(Task task, GithubTaskInfo githubInfo) {
+		log.debug("Resolving status for task: {}, githubInfo: {}",
+			task.getTaskId(), githubInfo);
+
+		// Fork가 없는 경우
+		if (!githubInfo.isForkExist()) {
+			return TaskStatus.NOT_STARTED;
+		}
+
+		// PR이 없는 경우
+		if (!githubInfo.hasPullRequest()) {
+			// 기존에 진행 중이었다면 유지, 아니면 FORKED
+			return task.getStatus() == TaskStatus.PROGRESS
+				? TaskStatus.PROGRESS : TaskStatus.FORKED;
+		}
+
+		// PR이 있는 경우 상태별 판단
+		if (githubInfo.isPullRequestMerged()) {
+			return TaskStatus.MERGED;
+		} else if (githubInfo.isPullRequestClosed()) {
+			return TaskStatus.REJECTED;
+		} else if (githubInfo.isHasReview()) {
+			return TaskStatus.REVIEW;
+		} else {
+			return TaskStatus.PR;
+		}
+	}
+}

--- a/src/main/java/com/chungang/capstone/openstep/domain/Task/service/TaskUpdateService.java
+++ b/src/main/java/com/chungang/capstone/openstep/domain/Task/service/TaskUpdateService.java
@@ -1,0 +1,54 @@
+package com.chungang.capstone.openstep.domain.Task.service;
+
+import java.util.Objects;
+
+import org.springframework.stereotype.Service;
+
+import com.chungang.capstone.openstep.domain.Github.dto.GithubTaskInfo;
+import com.chungang.capstone.openstep.domain.Task.entity.Task;
+import com.chungang.capstone.openstep.domain.Task.entity.TaskStatus;
+import com.chungang.capstone.openstep.domain.Task.repository.TaskRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TaskUpdateService {
+
+	private final TaskRepository taskRepository;
+
+	//github info 기반으로 Task 엔티티 업데이트
+
+	public boolean updateTaskByGithubInfo(Task task, TaskStatus newStatus, GithubTaskInfo githubInfo) {
+		boolean needsUpdate = false;
+
+		// 상태 업데이트
+		if (task.getStatus() != newStatus) {
+			log.info("Updating task status: {} -> {} for task: {}",
+				task.getStatus(), newStatus, task.getTaskId());
+			task.updateStatus(newStatus);
+			needsUpdate = true;
+		}
+
+		// PR URL 업데이트
+		if (githubInfo.hasPullRequest()) {
+			String newPrUrl = githubInfo.getPrUrl();
+			if (!Objects.equals(task.getPrUrl(), newPrUrl)) {
+				log.info("Updating PR URL for task: {}, new URL: {}",
+					task.getTaskId(), newPrUrl);
+				task.updatePrUrl(newPrUrl);
+				needsUpdate = true;
+			}
+		}
+
+		// 변경사항이 있을 때만 저장
+		if (needsUpdate) {
+			taskRepository.save(task);
+			log.debug("Task updated and saved: {}", task.getTaskId());
+		}
+
+		return needsUpdate;
+	}
+}

--- a/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/chungang/capstone/openstep/global/apiPayload/code/status/ErrorStatus.java
@@ -59,7 +59,6 @@ public enum ErrorStatus implements BaseErrorCode {
     TASK_PR_URL_UPDATE_ERROR_INVALID_URL(HttpStatus.BAD_REQUEST, "TASK_4002", "PR URL 형식이 올바르지 않습니다.https://github.com/<owner>/<repo>/pull/<pr-number>"),
     TASK_PR_URL_UPDATE_ERROR_EXCEPT_FORKED(HttpStatus.BAD_REQUEST, "TASK_4002", "PR URL 업데이트는 FORKED 상태에서는 불가능합니다"),
     TASK_STATUS_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "TASK_4003", "테스크 상태 업데이트는 FORKED -> PROGRESS만 가능합니다."),
-    TASK_PR_URL_INVALID(HttpStatus.BAD_REQUEST, "TASK_4003", "PR URL 형식이 올바르지 않습니다."),
 
     // Rank 관련 에러 5000
     RANK_NOT_FOUND(HttpStatus.NOT_FOUND,"RANK_4001", "해당 사용자의 랭킹 정보를 찾을 수 없습니다.");


### PR DESCRIPTION
# 🔄 GitHub 상태 동기화 로직 리팩토링 및 책임 분리

## #️⃣연관된 이슈
> Task의 GitHub 상태 동기화 로직이 여러 서비스에 중복되어 있고, 책임이 혼재되어 있는 문제 해결

## 📝작업 내용

### 1. GitHub 정보 수집 서비스 분리
- **GitHubInfoService**: GitHub API 호출을 최소화하여 Task 관련 정보를 한 번에 수집
- **GitHubTaskInfo DTO**: Fork 존재 여부, PR 정보, 리뷰 상태를 포함하는 종합 정보 객체

### 2. 책임별 서비스 분리
- **TaskStatusResolver**: GitHub 정보를 바탕으로 TaskStatus 결정하는 비즈니스 로직
- **TaskUpdateService**: Task 엔티티 업데이트 (상태, PR URL) 전담
- **TaskEventService**: Task 상태 변경 관련 이벤트 발행 전담

### 3. 이벤트 기반 XP 처리 분리
- **TaskXpEventListener**: XP 부여 로직을 이벤트 리스너로 분리하여 Task 업데이트와 독립적으로 처리

## 🔎코드 설명 및 참고 사항

### Before (기존 코드의 문제점)
```java
// 매번 반복되는 패턴 - 책임 혼재
public TaskResponseDTO.Status getStatusByTaskId(Long taskId, Member member) {
    Task task = taskRepository.findById(taskId).orElseThrow(...);
    TaskStatus oldStatus = task.getStatus();
    TaskStatus resolvedStatus = githubStatusResolver.resolveStatus(task, member);
    
    if (oldStatus != resolvedStatus) {
        task.updateStatus(resolvedStatus);
        taskRepository.save(task); // PR URL 업데이트 누락
        handleXpGranting(member, task, resolvedStatus); // XP 로직 혼재
    }
    return TaskConverter.toTaskStatus(task);
}
```

### After (개선된 구조)
```java
// 명확한 책임 분리 + 공통 로직 재사용
public TaskResponseDTO.Status getStatusByTaskId(Long taskId, Member member) {
    Task task = syncTaskWithGitHub(taskId, member);
    return TaskConverter.toTaskStatus(result.getTask());
}
```

### 주요 개선사항

1. **GitHub API 호출 최적화**
   - 기존: Fork 체크 → PR 조회 → 리뷰 체크 (개별 호출)
   - 개선: `GitHubInfoService.getTaskInfo()`로 한 번에 수집

2. **PR URL 자동 업데이트**
   - GitHub에서 PR 정보 조회 시 `htmlUrl` 자동 업데이트
   - API URL이 아닌 사용자가 접근 가능한 웹 URL 저장

3. **중복 저장 방지**
   - 기존: `updateTaskByGithubInfo()` + `taskRepository.save()` 이중 저장
   - 개선: 한 번만 저장하도록 최적화

4. **트랜잭션 안정성**
   - `@Transactional` 범위 내에서 엔티티 변경사항 자동 반영
   - 프록시 객체 문제 해결
